### PR TITLE
Increase screen capture resolution

### DIFF
--- a/dialoghelper/screenshot.js
+++ b/dialoghelper/screenshot.js
@@ -14,7 +14,7 @@ function sendDataToServer(dataId, data) {
     });
 }
 
-async function streamToBlob(stream, maxWidth = 512, maxHeight = 512) {
+async function streamToBlob(stream, maxWidth = 1280, maxHeight = 1024) {
   return new Promise((resolve, reject) => {
     const video = document.createElement("video");
     video.srcObject = stream;


### PR DESCRIPTION
IMPORTANT: This PR is a branches off of https://github.com/AnswerDotAI/dialoghelper/tree/austinvhuang/blocking-refactor do not merge until https://github.com/AnswerDotAI/dialoghelper/pull/29 is merged

Previously screen captures would fail for images any larger than a 512x512 limit.

After https://github.com/AnswerDotAI/solveit/pull/734 and
https://github.com/AnswerDotAI/dialoghelper/pull/29 we are able to bump that up the resolution limit without issues. 

This PR makes a one line change to change the limit to 1280x1024 (preserving the native aspect ratio). Doing so lets solveit "see" rendered text in desktop applications more clearly.

Qualitatively this lets the LLM read text on the screen that's the size of ~10 pt font in a google doc, whereas with the previous 512x512 setting, reading failed (would start hallucinating) at around ~20 pt font.

Obviously for purely reading documents, it would be easier to supply the document as text, but this is jsut a proxy general ability to see text in other applications running on the computer.

Readability limit in this PR ~ 10pt:
<img width="1507" height="847" alt="image" src="https://github.com/user-attachments/assets/fe110fee-edf1-4d73-8318-2396d754716f" />

vs previously (512x512 max) ~ 20pt:
<img width="1510" height="923" alt="image" src="https://github.com/user-attachments/assets/67e7f355-3310-43f8-aa1b-25897a49d6e2" />
