### PR TITLE
use call_endp to pop

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -118,8 +118,7 @@ def iife(code: str) -> str:
 
 # %% ../nbs/00_core.ipynb
 def pop_data(idx, timeout=15):
-    url = 'http://localhost:5001/pop_data_blocking_'
-    return dict2obj(xpost(url, data={'data_id': idx, 'timeout': timeout}).json())
+    return dict2obj(call_endp('pop_data_blocking_', data_id=idx, timeout=timeout, json=True))
 
 # %% ../nbs/00_core.ipynb
 def fire_event(evt:str, data=None):

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -438,8 +438,7 @@
    "source": [
     "#| export\n",
     "def pop_data(idx, timeout=15):\n",
-    "    url = 'http://localhost:5001/pop_data_blocking_'\n",
-    "    return dict2obj(xpost(url, data={'data_id': idx, 'timeout': timeout}).json())"
+    "    return dict2obj(call_endp('pop_data_blocking_', data_id=idx, timeout=timeout, json=True))"
    ]
   },
   {


### PR DESCRIPTION
This PR removes the hardcoded url used in pop_data for `call_endp` instead. This allows dialoghelper users to continue to use non-default ports when using tools like `capture_screen`