### PR TITLE
Clarify add_msg docstring behavior

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -191,7 +191,7 @@ def read_msg(
 def add_msg(
     content:str, # Content of the message (i.e the message prompt, code, or note text)
     placement:str='add_after', # Can be 'add_after', 'add_before', 'at_start', 'at_end'
-    msgid:str=None, # id of message that placement is relative to (if None, uses current message)
+    msgid:str=None, # id of message that placement is relative to (if None, uses current message; note: each add_msg updates "current" to the newly created message)
     msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'
     output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array
     time_run: str | None = '', # When was message executed

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -630,7 +630,7 @@
     "def add_msg(\n",
     "    content:str, # Content of the message (i.e the message prompt, code, or note text)\n",
     "    placement:str='add_after', # Can be 'add_after', 'add_before', 'at_start', 'at_end'\n",
-    "    msgid:str=None, # id of message that placement is relative to (if None, uses current message)\n",
+    "    msgid:str=None, # id of message that placement is relative to (if None, uses current message; note: each add_msg updates \"current\" to the newly created message)\n",
     "    msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'\n",
     "    output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array\n",
     "    time_run: str | None = '', # When was message executed\n",


### PR DESCRIPTION
Clarifies that each `add_msg` call updates the "current" message reference.

This addresses confusion from #61 where users expected `placement='add_after'` to always refer to the original executing cell, rather than the last message created.

The behavior is working as intended (allows chaining), but the docstring wasn't clear about it.