### PR TITLE
Improvements to capture_screen

### DIFF
--- a/dialoghelper/screenshot.js
+++ b/dialoghelper/screenshot.js
@@ -1,18 +1,23 @@
-document.body.addEventListener('shareScreen', async e => 
-    window.vtrack = (await navigator.mediaDevices.getDisplayMedia()).getVideoTracks()[0]
-);
+const noTrack = () => (!window.vtrack || window.vtrack.readyState === 'ended');
 
 window.getScreenshot = async (mxw=1280, mxh=1024) => {
-    if (!window?.vtrack) return;
+    if (noTrack()) return;
     const img = await new ImageCapture(window.vtrack).grabFrame();
     const scale = Math.min(mxw/img.width, mxh/img.height, 1);
     const c = document.createElement('canvas');
     [c.width, c.height] = [img.width*scale, img.height*scale].map(Math.floor);
     c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+    img.close();
     return c.toDataURL();
 }
-
-document.body.addEventListener('captureScreen', async e =>
-    pushData(e.detail.idx, {img_data: await getScreenshot()})
-);
-
+    
+if (!window._registered) {
+    window._registered = true;
+    document.body.addEventListener('shareScreen', async () => {
+        if (noTrack()) window.vtrack = (await navigator.mediaDevices.getDisplayMedia()).getVideoTracks()[0];
+    });
+    document.body.addEventListener('captureScreen', async e => {
+        if (noTrack()) return;
+        pushData(e.detail.idx, {img_data: await getScreenshot()})
+    });
+}

--- a/nbs/01_capture.ipynb
+++ b/nbs/01_capture.ipynb
@@ -214,6 +214,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  },
   "solveit_dialog_mode": "concise",
   "solveit_ver": 2
  },


### PR DESCRIPTION
This PR ensure `setup_share()` and `start_share()` in the capture API only define event-listeners once. While a track is running, calling `start_share()` will no longer prompt to start another concurrent screen-share.