### PR TITLE
Add type annotations to shell_ret for proper is_usable_tool report

### DIFF
--- a/dialoghelper/tmux.py
+++ b/dialoghelper/tmux.py
@@ -23,7 +23,7 @@ def _ssh(
 
 # %% ../nbs/03_tmux.ipynb
 @delegates(_ssh)
-def shell_ret(cmd, capture_output=True, text=True, ret=True, **kwargs):
+def shell_ret(cmd:str, capture_output: bool=True, text: bool=True, ret: bool=True, **kwargs):
     "Run shell command locally or over ssh (use host for alias, or ip/user/keyfile)"
     host, ip, user, keyfile = kwargs.pop('host', None), kwargs.pop('ip', None), kwargs.pop('user', None), kwargs.pop('keyfile', None)
     if host: cmd = f"echo '{cmd}' | ssh -A {host} 'bash -ls'"

--- a/nbs/03_tmux.ipynb
+++ b/nbs/03_tmux.ipynb
@@ -226,7 +226,7 @@
    "source": [
     "#| export\n",
     "@delegates(_ssh)\n",
-    "def shell_ret(cmd, capture_output=True, text=True, ret=True, **kwargs):\n",
+    "def shell_ret(cmd:str, capture_output: bool=True, text: bool=True, ret: bool=True, **kwargs):\n",
     "    \"Run shell command locally or over ssh (use host for alias, or ip/user/keyfile)\"\n",
     "    host, ip, user, keyfile = kwargs.pop('host', None), kwargs.pop('ip', None), kwargs.pop('user', None), kwargs.pop('keyfile', None)\n",
     "    if host: cmd = f\"echo '{cmd}' | ssh -A {host} 'bash -ls'\"\n",


### PR DESCRIPTION
Adds type annotations to `shell_ret` parameters. Since tmux tools use `@delegates(shell_ret)`, this ensures `is_usable_tool` correctly identifies them as valid tools.
