### PR TITLE
Use json=False for del_msg to match rm_msg_ response

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -275,7 +275,7 @@ def del_msg(
     dname:str='' # Dialog to get info for; defaults to current dialog
 ):
     "Delete a message from the dialog. DO NOT USE THIS unless you have been explicitly instructed to delete messages."
-    return call_endp('rm_msg_', dname, raiseex=True, msid=id, json=True)
+    return call_endp('rm_msg_', dname, raiseex=True, msid=id, json=False)
 
 # %% ../nbs/00_core.ipynb
 @delegates(add_msg)

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1006,7 +1006,7 @@
     "    dname:str='' # Dialog to get info for; defaults to current dialog\n",
     "):\n",
     "    \"Delete a message from the dialog. DO NOT USE THIS unless you have been explicitly instructed to delete messages.\"\n",
-    "    return call_endp('rm_msg_', dname, raiseex=True, msid=id, json=True)"
+    "    return call_endp('rm_msg_', dname, raiseex=True, msid=id, json=False)"
    ]
   },
   {


### PR DESCRIPTION
The `rm_msg_` endpoint returns a plain string (the deleted message id) not JSON, so `del_msg` should use `json=False`.

Part of the fix to make `del_msg` work on plain notebooks (companion to solveit PR #1367).