### PR TITLE
Fix cross dlg pollution

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -346,7 +346,7 @@ def update_msg(
     if not id: id = kwargs.pop('id', None)
     if not id: raise TypeError("update_msg needs either a dict message with and id, or `id=`")
     res = call_endp('update_msg_', dname, id=id, **kwargs)
-    if notdname: set_var('__msg_id', res)
+    if not dname: set_var('__msg_id', res)
     return res
 
 # %% ../nbs/00_core.ipynb #316bd7a0

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1206,7 +1206,7 @@
     "    if not id: id = kwargs.pop('id', None)\n",
     "    if not id: raise TypeError(\"update_msg needs either a dict message with and id, or `id=`\")\n",
     "    res = call_endp('update_msg_', dname, id=id, **kwargs)\n",
-    "    if notdname: set_var('__msg_id', res)\n",
+    "    if not dname: set_var('__msg_id', res)\n",
     "    return res"
    ]
   },


### PR DESCRIPTION
## Demonstrates add_msg pollution bug across dialogs
### Setup: Create two dialogs, 'dlg_a' and 'dlg_b'
In 'dlg_a', run this code in the same message:

```python
msg1 = add_msg("Message in dlg_b", dname='dlg_b', placement='at_end')
print(f"Created {msg1} in dlg_b")
print(f"__msg_id is now: {__msg_id}")

# Now add a message to this dialog (dlg_a)

msg2 = add_msg("Message in same dialog")
print(f"Created {msg2} - should be in dlg_a, after msg1")
```

## Bug:
msg2 doesn't get created anywhere because `__msg_id` in 'dlg_a' scope was set by the first `add_msg` call with a message id from `dlg_b`.

**Impact:** Any function that calls `add_msg` with different `dname` values pollutes the caller's `__msg_id`, breaking subsequent message placement. If the add_msg calls happen in different messages, __msg_id is reset to the message id and the issue won't happen.

**Possible fix:** add_msg should call set_var('__msg_id', ...) only if dname parameter is not set.

**Workaround:** Always pass explicit `id` and `placement` parameters when calling several `add_msg` after cross-dialog operations in one message.