### PR TITLE
Update add_scr to use ephemeral OOB target

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -124,8 +124,8 @@ def msg_idx(
     return call_endp('msg_idx_', dname, json=True, id=id)['idx']
 
 # %% ../nbs/00_core.ipynb #4b43e4e9
-def add_scr(scr, oob='beforeend:#js-script'):
-    "Swap a script element to the end of the js-script element"
+def add_scr(scr, oob='beforeend:#ephemeral'):
+    "Swap a script element to the end of the ephemeral element"
     if isinstance(scr,str): scr = Script(scr)
     add_html(Div(scr, hx_swap_oob=oob))
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -506,8 +506,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def add_scr(scr, oob='beforeend:#js-script'):\n",
-    "    \"Swap a script element to the end of the js-script element\"\n",
+    "def add_scr(scr, oob='beforeend:#ephemeral'):\n",
+    "    \"Swap a script element to the end of the ephemeral element\"\n",
     "    if isinstance(scr,str): scr = Script(scr)\n",
     "    add_html(Div(scr, hx_swap_oob=oob))"
    ]


### PR DESCRIPTION
Solveit refactored JS injection to use `#ephemeral` instead of `#js-script` in commit 6711a0a7. This updates dialoghelper to match.

Fixes `setup_share()` and other functions that use `add_scr()` to inject JavaScript.