### PR TITLE
add missing imports

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -460,6 +460,8 @@ def dialog_link(
 ):
     """Return an IPython HTML link to open a dialog in Solveit.
     After calling this tool, output the resulting HTML anchor tag exactly as returned—do not wrap in a fenced code block or convert to markdown link format."""
+    from urllib.parse import urlencode
+    from IPython.display import HTML
     path = path.removeprefix('/')
     url = f"/dialog_?{urlencode({'name': path})}"
     return HTML(f'<a href="{url}" target="_blank">{path}</a>')

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1993,6 +1993,8 @@
     "):\n",
     "    \"\"\"Return an IPython HTML link to open a dialog in Solveit.\n",
     "    After calling this tool, output the resulting HTML anchor tag exactly as returned—do not wrap in a fenced code block or convert to markdown link format.\"\"\"\n",
+    "    from urllib.parse import urlencode\n",
+    "    from IPython.display import HTML\n",
     "    path = path.removeprefix('/')\n",
     "    url = f\"/dialog_?{urlencode({'name': path})}\"\n",
     "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{path}</a>')"


### PR DESCRIPTION
Added lazy imports for `urlencode` and `HTML` inside `dialog_link()` which were used but not imported, causing `NameError` when called.