### PR TITLE
_add_msg_unsafe names kwargs to capture default values

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -315,14 +315,22 @@ def del_msg(
 
 
 # %% ../nbs/00_core.ipynb #a9614fcc
-@delegates(add_msg)
 def _add_msg_unsafe(
     content:str, # Content of the message (i.e the message prompt, code, or note text)
     placement:str='add_after', # Can be 'at_start' or 'at_end', and for default dname can also be 'add_after' or 'add_before'
     id:str=None, # id of message that placement is relative to (if None, uses current message)
     run:bool=False, # For prompts, send it to the AI; for code, execute it (*DANGEROUS -- be careful of what you run!)
     dname:str='', # Dialog to get info for; defaults to current dialog (`run` only has a effect if dialog is currently running)
-    **kwargs
+
+    msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'
+    output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array
+    time_run: str | None = '', # When was message executed
+    is_exported: int | None = 0, # Export message to a module?
+    skipped: int | None = 0, # Hide message from prompt?
+    i_collapsed: int | None = 0, # Collapse input?
+    o_collapsed: int | None = 0, # Collapse output?
+    heading_collapsed: int | None = 0, # Collapse heading section?
+    pinned: int | None = 0, # Pin to context?
 )->str: # Message ID of newly created message
     """Add/update a message to the queue to show after code execution completes, and optionally run it.
     **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,
@@ -331,7 +339,10 @@ def _add_msg_unsafe(
     _diff_dialog(placement not in ('at_start','at_end'), dname,
         "`id` or `placement='at_end'`/`placement='at_start'` must be provided when target dialog is different", id=id)    
     if placement not in ('at_start','at_end') and not id: id = find_msg_id()
-    res = call_endp( 'add_relative_', dname, content=content, placement=placement, id=id, run=run, **kwargs)
+    res = call_endp( 'add_relative_', dname, content=content, placement=placement, id=id, run=run,
+                     msg_type=msg_type, output=output, time_run=time_run, is_exported=is_exported,
+                     skipped=skipped, i_collapsed=i_collapsed, o_collapsed=o_collapsed,
+                     heading_collapsed=heading_collapsed, pinned=pinned)
     return res
 
 # %% ../nbs/00_core.ipynb #023dcb74

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -956,13 +956,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "_9c544573\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "_9c544573\n",
       "_9c544573\n"
      ]
     }
@@ -1088,14 +1082,22 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "@delegates(add_msg)\n",
     "def _add_msg_unsafe(\n",
     "    content:str, # Content of the message (i.e the message prompt, code, or note text)\n",
     "    placement:str='add_after', # Can be 'at_start' or 'at_end', and for default dname can also be 'add_after' or 'add_before'\n",
     "    id:str=None, # id of message that placement is relative to (if None, uses current message)\n",
     "    run:bool=False, # For prompts, send it to the AI; for code, execute it (*DANGEROUS -- be careful of what you run!)\n",
     "    dname:str='', # Dialog to get info for; defaults to current dialog (`run` only has a effect if dialog is currently running)\n",
-    "    **kwargs\n",
+    "\n",
+    "    msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'\n",
+    "    output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array\n",
+    "    time_run: str | None = '', # When was message executed\n",
+    "    is_exported: int | None = 0, # Export message to a module?\n",
+    "    skipped: int | None = 0, # Hide message from prompt?\n",
+    "    i_collapsed: int | None = 0, # Collapse input?\n",
+    "    o_collapsed: int | None = 0, # Collapse output?\n",
+    "    heading_collapsed: int | None = 0, # Collapse heading section?\n",
+    "    pinned: int | None = 0, # Pin to context?\n",
     ")->str: # Message ID of newly created message\n",
     "    \"\"\"Add/update a message to the queue to show after code execution completes, and optionally run it.\n",
     "    **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,\n",
@@ -1104,7 +1106,10 @@
     "    _diff_dialog(placement not in ('at_start','at_end'), dname,\n",
     "        \"`id` or `placement='at_end'`/`placement='at_start'` must be provided when target dialog is different\", id=id)    \n",
     "    if placement not in ('at_start','at_end') and not id: id = find_msg_id()\n",
-    "    res = call_endp( 'add_relative_', dname, content=content, placement=placement, id=id, run=run, **kwargs)\n",
+    "    res = call_endp( 'add_relative_', dname, content=content, placement=placement, id=id, run=run,\n",
+    "                     msg_type=msg_type, output=output, time_run=time_run, is_exported=is_exported,\n",
+    "                     skipped=skipped, i_collapsed=i_collapsed, o_collapsed=o_collapsed,\n",
+    "                     heading_collapsed=heading_collapsed, pinned=pinned)\n",
     "    return res"
    ]
   },
@@ -1346,20 +1351,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This message should be found.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "This message should be found.\n",
+      "\n",
       "This is a multiline message.\n"
      ]
     }
@@ -1378,20 +1371,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This message should be found.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This message should be found.\n",
+      "     2 │ \n",
       "     3 │ This is a multiline message.\n"
      ]
     }
@@ -1410,13 +1391,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     2 │ \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     2 │ \n",
       "     3 │ This is a multiline message.\n"
      ]
     }
@@ -2149,41 +2124,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the first line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ This message should be found.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     3 │ \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     4 │ This should go to the 4th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     5 │ This is a multiline message.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This should go to the first line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ This is a multiline message.\n",
       "     6 │ This should go to the last line\n"
      ]
     }
@@ -2241,41 +2186,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ This message should be found.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     3 │ \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     4 │ This should go to the 4th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     5 │ This is a multiline message.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ This is a multiline message.\n",
       "     6 │ This should go to the last line\n"
      ]
     }
@@ -2338,41 +2253,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ This message should be found.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     3 │ \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     4 │ This should go to the 4th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     5 │ 5th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ 5th line\n",
       "     6 │ last line\n"
      ]
     }
@@ -2448,41 +2333,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ line 2\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     3 │ line 3\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     4 │ line 4\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     5 │ 5th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ line 2\n",
+      "     3 │ line 3\n",
+      "     4 │ line 4\n",
+      "     5 │ 5th line\n",
       "     6 │ last line\n"
      ]
     }
@@ -2540,20 +2395,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     2 │ 5th line\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ 5th line\n",
       "     3 │ last line\n"
      ]
     }
@@ -3078,27 +2921,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"This is a test module which makes some simple tools available.\"\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "__all__ = [\"hi\",\"whoami\"]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\"This is a test module which makes some simple tools available.\"\n",
+      "__all__ = [\"hi\",\"whoami\"]\n",
+      "\n",
       "testfoo=…\n"
      ]
     }
@@ -3380,7 +3205,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
I worked on this with @erikgaas today.

Updates _add_msg_unsafe to name its keyword arguments explicitly instead of getting them from @delegates(add_msg).

The motivation for this is that @delegates was capturing the keyword argument names and types, but not the default values.

As a result, when _add_msg_unsafe was called directly with no values supplied for keyword arguments, like i_collapsed, those arguments would be passed as Unset, to `add_relative_`, leading to crashes down the call chain.