### PR TITLE
Let `run_python` to use user globals, not .core globals to access tools and variables.

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -75,8 +75,9 @@ def _safe_getattr(obj, name):
 
 # %% ../nbs/00_core.ipynb #c56b1f7e
 def _run_python(code:str):
-    tools = {k: globals()[k] for k in __llmtools__ if k in globals()}
-    tools |= {k:v for k,v in globals().items() if not callable(v) and not k.startswith('_')}
+    g = _find_frame_dict('__msg_id')
+    tools = {k: g.get(k) for k in __llmtools__ if k in g}
+    tools |= {k:v for k,v in g.items() if not callable(v) and not k.startswith('_')}
     def unpack(a,*args): return list(a)
     rg = dict(__builtins__=all_builtins, _getattr_=_safe_getattr,
               _getitem_=lambda o,k: o[k], _getiter_=iter,

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -260,8 +260,9 @@
    "source": [
     "#| export\n",
     "def _run_python(code:str):\n",
-    "    tools = {k: globals()[k] for k in __llmtools__ if k in globals()}\n",
-    "    tools |= {k:v for k,v in globals().items() if not callable(v) and not k.startswith('_')}\n",
+    "    g = _find_frame_dict('__msg_id')\n",
+    "    tools = {k: g.get(k) for k in __llmtools__ if k in g}\n",
+    "    tools |= {k:v for k,v in g.items() if not callable(v) and not k.startswith('_')}\n",
     "    def unpack(a,*args): return list(a)\n",
     "    rg = dict(__builtins__=all_builtins, _getattr_=_safe_getattr,\n",
     "              _getitem_=lambda o,k: o[k], _getiter_=iter,\n",


### PR DESCRIPTION
The dialoghelper.core globals() have limited nubmer of tools (smaller than what `__llmtools__` define)
Tools like rg, sed, bash were not avaliable, same for user defined tools.

We change globals() to result of _find_frame_dict('__msg_id') (mechanism as inspecttools use).
