### PR TITLE
Fix add_msg defaults: delegate to _add_msg_unsafe

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "955b9784",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:57.952742+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| default_exp core"
@@ -16,43 +14,8 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a982e24d",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:57.981092+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name '_add_msg_unsafe' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mdialoghelper\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m *",
-      "",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/aai-ws/dialoghelper/dialoghelper/__init__.py:2\u001b[39m",
-      "\u001b[32m      1\u001b[39m __version__ = \u001b[33m\"\u001b[39m\u001b[33m0.2.2\u001b[39m\u001b[33m\"\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mcore\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m *",
-      "",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/aai-ws/dialoghelper/dialoghelper/core.py:391\u001b[39m",
-      "\u001b[32m    387\u001b[39m Placements = str_enum(\u001b[33m'\u001b[39m\u001b[33mPlacements\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33madd_after\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33madd_before\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mat_start\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mat_end\u001b[39m\u001b[33m'\u001b[39m)",
-      "\u001b[32m    389\u001b[39m \u001b[38;5;66;03m# %% ../nbs/00_core.ipynb #3ad14786\u001b[39;00m",
-      "\u001b[32m    390\u001b[39m \u001b[38;5;129m@llmtool\u001b[39m(dname=dname_doc)",
-      "\u001b[32m--> \u001b[39m\u001b[32m391\u001b[39m \u001b[38;5;129m@delegates\u001b[39m(\u001b[43m_add_msg_unsafe\u001b[49m, but=[\u001b[33m'\u001b[39m\u001b[33mrun\u001b[39m\u001b[33m'\u001b[39m])",
-      "\u001b[32m    392\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34madd_msg\u001b[39m(",
-      "\u001b[32m    393\u001b[39m     content:\u001b[38;5;28mstr\u001b[39m, \u001b[38;5;66;03m# Content of the message (i.e the message prompt, code, or note text)\u001b[39;00m",
-      "\u001b[32m    394\u001b[39m     **kwargs",
-      "\u001b[32m    395\u001b[39m )->\u001b[38;5;28mstr\u001b[39m: \u001b[38;5;66;03m# Message ID of newly created message\u001b[39;00m",
-      "\u001b[32m    396\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Add/update a message to the queue to show after code execution completes.\u001b[39;00m",
-      "\u001b[32m    397\u001b[39m \u001b[33;03m    **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,\u001b[39;00m",
-      "\u001b[32m    398\u001b[39m \u001b[33;03m    otherwise messages will appear in the dialog in REVERSE order.\u001b[39;00m",
-      "\u001b[32m    399\u001b[39m \u001b[33;03m    {dname}\"\"\"\u001b[39;00m",
-      "\u001b[32m    400\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m _add_msg_unsafe(content=content, run=\u001b[38;5;28;01mFalse\u001b[39;00m, **kwargs)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name '_add_msg_unsafe' is not defined"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from dialoghelper import *"
    ]
@@ -69,9 +32,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e881cda4",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.084074+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -101,9 +62,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e54b45ad",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.113238+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -114,9 +73,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0eac27d1",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.141791+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from fastcore import tools"
@@ -134,9 +91,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cc9f963f",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.172171+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -163,9 +118,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b9451ad8",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.200726+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import mistletoe\n",
@@ -176,9 +129,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f13fdf03",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.229535+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -186,7 +137,7 @@
        "'<h3>hi</h3>\\n<ul>\\n<li>first</li>\\n<li><em>second</em></li>\\n</ul>\\n'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,9 +151,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94c3f587",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.329853+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -229,9 +178,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1aab712",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.359934+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -266,9 +213,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bf3872ca",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.389583+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -280,9 +225,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f5fdf7df",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.417375+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -295,9 +238,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a7f1131",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.446854+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -313,9 +254,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c56b1f7e",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.477300+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -345,9 +284,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "67bd9bc7",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.506116+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -368,9 +305,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ade322da",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.535087+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -390,9 +325,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f80e3a63",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.564407+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -417,9 +350,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb0489a1",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.592968+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -427,7 +358,7 @@
        "1"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,9 +372,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cec6f088",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.699602+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -451,7 +380,7 @@
        "42"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,9 +394,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eb1636a6",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.729588+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -478,9 +405,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8c809b6d",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.758005+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# dh_settings = {'port':6001}"
@@ -490,9 +415,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a01ad161",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.789566+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -522,9 +445,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1930a9ce",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.819707+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -532,7 +453,7 @@
        "'/aai-ws/dialoghelper/nbs/00_core'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -545,9 +466,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bfecc90c",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.848551+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -555,7 +474,7 @@
        "'/aai-ws/dialoghelper/nbs/index'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -568,9 +487,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "294995f3",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.877817+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -578,7 +495,7 @@
        "'/aai-ws/dialoghelper/index'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -591,9 +508,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "78e6e1a7",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.907876+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -601,7 +516,7 @@
        "'/foo/bar'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -614,9 +529,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "39232620",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.942024+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -630,9 +543,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bdac4ecb",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:58.976216+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -654,9 +565,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5fc896fe",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.079387+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -673,9 +582,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9cbd170d",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.109543+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -683,7 +590,7 @@
        "'_9cbd170d'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -696,9 +603,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a9cb5512",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.139089+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -716,9 +621,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8810450f",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.169850+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -737,9 +640,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "751dd86e",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.200730+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -747,7 +648,7 @@
        "36"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -760,9 +661,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5335c78c",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.294059+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -787,9 +686,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a8e79a9a",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.321476+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from fasthtml.common import *"
@@ -799,9 +696,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3bc464f8",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.352345+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -809,7 +704,7 @@
        "{'success': 'Content added to DOM'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -822,9 +717,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b43e4e9",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.450092+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -843,9 +736,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6f1b12d3",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.479737+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -869,9 +760,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "99a07c05",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.507952+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -886,9 +775,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ddcee8d5",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.536223+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -905,9 +792,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "25ed8a64",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.564353+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -932,9 +817,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e2d1a5be",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.627535+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -955,9 +838,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "80334098",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.655221+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -979,9 +860,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f819e9bd",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.683979+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -997,9 +876,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "558c6aa7",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.711942+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1030,9 +907,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6a4aa03b",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.765535+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1073,9 +948,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aa444dff",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.793172+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# NB: must have a dialogue open including a message with this text in its content\n",
@@ -1087,9 +960,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8ce548d6",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.880055+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1097,7 +968,7 @@
        "2"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1110,9 +981,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "df4be3ff",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.908541+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1120,7 +989,7 @@
        "[{'id': '_8ce548d6', 'is_exported': 0, 'content': '1+1', 'output': '2', 'msg_type': 'code'}, {'id': '_44cb1b2a', 'is_exported': 0, 'content': \"_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')\", 'output': '', 'msg_type': 'code'}, {'id': '_6e354677', 'is_exported': 0, 'content': '1+1', 'output': '', 'msg_type': 'code'}]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1134,9 +1003,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bd06bf55",
-   "metadata": {
-    "time_run": "2026-02-10T21:01:59.994685+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1149,7 +1016,7 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1162,9 +1029,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9ff2a38e",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.100123+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1186,9 +1051,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b5cb1f3b",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.128606+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1207,7 +1070,7 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1220,9 +1083,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fdc5a465",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.219915+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1232,268 +1093,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ad14786",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.252470+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name '_add_msg_unsafe' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 2\u001b[39m",
-      "\u001b[32m      1\u001b[39m \u001b[38;5;129m@llmtool\u001b[39m(dname=dname_doc)",
-      "\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;129m@delegates\u001b[39m(\u001b[43m_add_msg_unsafe\u001b[49m, but=[\u001b[33m'\u001b[39m\u001b[33mrun\u001b[39m\u001b[33m'\u001b[39m])",
-      "\u001b[32m      3\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34madd_msg\u001b[39m(",
-      "\u001b[32m      4\u001b[39m     content:\u001b[38;5;28mstr\u001b[39m, \u001b[38;5;66;03m# Content of the message (i.e the message prompt, code, or note text)\u001b[39;00m",
-      "\u001b[32m      5\u001b[39m     **kwargs",
-      "\u001b[32m      6\u001b[39m )->\u001b[38;5;28mstr\u001b[39m: \u001b[38;5;66;03m# Message ID of newly created message\u001b[39;00m",
-      "\u001b[32m      7\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Add/update a message to the queue to show after code execution completes.\u001b[39;00m",
-      "\u001b[32m      8\u001b[39m \u001b[33;03m    **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,\u001b[39;00m",
-      "\u001b[32m      9\u001b[39m \u001b[33;03m    otherwise messages will appear in the dialog in REVERSE order.\u001b[39;00m",
-      "\u001b[32m     10\u001b[39m \u001b[33;03m    {dname}\"\"\"\u001b[39;00m",
-      "\u001b[32m     11\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m _add_msg_unsafe(content=content, run=\u001b[38;5;28;01mFalse\u001b[39;00m, **kwargs)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name '_add_msg_unsafe' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "#| export\n",
-    "@llmtool(dname=dname_doc)\n",
-    "@delegates(_add_msg_unsafe, but=['run'])\n",
-    "async def add_msg(\n",
-    "    content:str, # Content of the message (i.e the message prompt, code, or note text)\n",
-    "    **kwargs\n",
-    ")->str: # Message ID of newly created message\n",
-    "    \"\"\"Add/update a message to the queue to show after code execution completes.\n",
-    "    **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,\n",
-    "    otherwise messages will appear in the dialog in REVERSE order.\n",
-    "    {dname}\"\"\"\n",
-    "    return await _add_msg_unsafe(content=content, run=False, **kwargs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "afc62c45",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.288191+00:00"
-   },
-   "outputs": [],
-   "source": [
-    "#| export\n",
-    "@llmtool(dname=dname_doc)\n",
-    "async def read_msgid(\n",
-    "    id:str,  # Message id to find\n",
-    "    view_range:list[int,int]=None, # Optional 1-indexed (start, end) line range for files, end=-1 for EOF\n",
-    "    nums:bool=False, # Whether to show line numbers\n",
-    "    dname:str='', # Dialog to get message from; defaults to current dialog\n",
-    "    add_to_dlg:bool=False # Whether to add message content to current dialog (as a raw message)\n",
-    "):\n",
-    "    \"\"\"Get message `id`. Message IDs can be view directly in LLM chat history/context, or found in `find_msgs` results.\n",
-    "    Use `add_to_dlg` if the LLM or human may need to refer to the message content again later.\n",
-    "    {dname}\"\"\"\n",
-    "    res = await read_msg(0, id=id, view_range=view_range, nums=nums, dname=dname)\n",
-    "    if add_to_dlg: await add_msg(res['content'], msg_type='raw')\n",
-    "    return res"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9c544573",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.320856+00:00"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_9c544573\n"
-     ]
-    },
-    {
-     "ename": "NameError",
-     "evalue": "name 'add_msg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 2\u001b[39m",
-      "\u001b[32m      1\u001b[39m \u001b[38;5;28mprint\u001b[39m(__msg_id)",
-      "\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m _id = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43madd_msg\u001b[49m(\u001b[33m'\u001b[39m\u001b[33mtesting\u001b[39m\u001b[33m'\u001b[39m)",
-      "\u001b[32m      3\u001b[39m \u001b[38;5;28mprint\u001b[39m(__msg_id)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'add_msg' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "print(__msg_id)\n",
-    "_id = await add_msg('testing')\n",
-    "print(__msg_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ebf0d896",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.354079+00:00"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "print(__msg_id)\n",
-      "_id = await add_msg('testing')\n",
-      "print(__msg_id)\n"
-     ]
-    }
-   ],
-   "source": [
-    "print((await read_msg()).content)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b85e21c7",
+   "id": "ca694d38",
    "metadata": {},
-   "source": [
-    "`read_msg` (and all endpoints that return json) wrap responses in `dict2obj`, so you can use either dict or object syntax."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "679f80cf",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.477743+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'add_msg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m bmsg = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43madd_msg\u001b[49m(\u001b[33m'\u001b[39m\u001b[33mat bottom\u001b[39m\u001b[33m'\u001b[39m, placement=\u001b[33m'\u001b[39m\u001b[33mat_end\u001b[39m\u001b[33m'\u001b[39m)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'add_msg' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "bmsg = await add_msg('at bottom', placement='at_end')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a67fc2f2",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.512680+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'bmsg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01massert\u001b[39;00m(\u001b[38;5;28;01mawait\u001b[39;00m msg_idx(\u001b[43mbmsg\u001b[49m)>\u001b[38;5;28;01mawait\u001b[39;00m msg_idx(_id)+\u001b[32m10\u001b[39m)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'bmsg' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "assert(await msg_idx(bmsg)>await msg_idx(_id)+10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "376b6e07",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.540573+00:00"
-   },
-   "outputs": [],
-   "source": [
-    "# dh_settings['dname'] = 'tmp'\n",
-    "# _id = await add_msg('testing', placement='at_end')\n",
-    "# print(_id)\n",
-    "# del(dh_settings['dname'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f1ee1903",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.569387+00:00"
-   },
-   "outputs": [],
-   "source": [
-    "#| export\n",
-    "@llmtool\n",
-    "async def del_msg(\n",
-    "    id:str=None, # id of message to delete\n",
-    "    dname:str='', # Dialog to get info for; defaults to current dialog\n",
-    "    log_changed:bool=False # Add a note showing the deleted content?\n",
-    "):\n",
-    "    \"Delete a message from the dialog. DO NOT USE THIS unless you have been explicitly instructed to delete messages.\"\n",
-    "    if log_changed: msg = await read_msgid(id, dname=dname)\n",
-    "    res = await call_endpa('rm_msg_', dname, raiseex=True, msid=id, json=True)\n",
-    "    if log_changed: await add_msg(f\"> Deleted #{id}\\n\\n```\\n{msg.content}\\n```\")\n",
-    "    return res\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9c6c959b",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.603671+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'bmsg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m del_msg(\u001b[43mbmsg\u001b[49m)",
-      "\u001b[32m      2\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m del_msg(_id)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'bmsg' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "await del_msg(bmsg)\n",
-    "await del_msg(_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a9614fcc",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.634075+00:00"
-   },
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1530,22 +1131,154 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44cb1b2a",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.663671+00:00"
-   },
+   "id": "3ad14786",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')"
+    "#| export\n",
+    "@llmtool(dname=dname_doc)\n",
+    "@delegates(_add_msg_unsafe, but=['run'])\n",
+    "async def add_msg(\n",
+    "    content:str, # Content of the message (i.e the message prompt, code, or note text)\n",
+    "    **kwargs\n",
+    ")->str: # Message ID of newly created message\n",
+    "    \"\"\"Add/update a message to the queue to show after code execution completes.\n",
+    "    **NB**: when creating multiple messages in a row, after the 1st message set `id` to the result of the last `add_msg` call,\n",
+    "    otherwise messages will appear in the dialog in REVERSE order.\n",
+    "    {dname}\"\"\"\n",
+    "    return await _add_msg_unsafe(content=content, run=False, **kwargs)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f1e0ee6",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.788282+00:00"
-   },
+   "id": "afc62c45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "@llmtool(dname=dname_doc)\n",
+    "async def read_msgid(\n",
+    "    id:str,  # Message id to find\n",
+    "    view_range:list[int,int]=None, # Optional 1-indexed (start, end) line range for files, end=-1 for EOF\n",
+    "    nums:bool=False, # Whether to show line numbers\n",
+    "    dname:str='', # Dialog to get message from; defaults to current dialog\n",
+    "    add_to_dlg:bool=False # Whether to add message content to current dialog (as a raw message)\n",
+    "):\n",
+    "    \"\"\"Get message `id`. Message IDs can be view directly in LLM chat history/context, or found in `find_msgs` results.\n",
+    "    Use `add_to_dlg` if the LLM or human may need to refer to the message content again later.\n",
+    "    {dname}\"\"\"\n",
+    "    res = await read_msg(0, id=id, view_range=view_range, nums=nums, dname=dname)\n",
+    "    if add_to_dlg: await add_msg(res['content'], msg_type='raw')\n",
+    "    return res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c544573",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_9c544573\n",
+      "_9c544573\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(__msg_id)\n",
+    "_id = await add_msg('testing')\n",
+    "print(__msg_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebf0d896",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "testing\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((await read_msg()).content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b85e21c7",
+   "metadata": {},
+   "source": [
+    "`read_msg` (and all endpoints that return json) wrap responses in `dict2obj`, so you can use either dict or object syntax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "679f80cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bmsg = await add_msg('at bottom', placement='at_end')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a67fc2f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(await msg_idx(bmsg)>await msg_idx(_id)+10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "376b6e07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dh_settings['dname'] = 'tmp'\n",
+    "# _id = await add_msg('testing', placement='at_end')\n",
+    "# print(_id)\n",
+    "# del(dh_settings['dname'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1ee1903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "@llmtool\n",
+    "async def del_msg(\n",
+    "    id:str=None, # id of message to delete\n",
+    "    dname:str='', # Dialog to get info for; defaults to current dialog\n",
+    "    log_changed:bool=False # Add a note showing the deleted content?\n",
+    "):\n",
+    "    \"Delete a message from the dialog. DO NOT USE THIS unless you have been explicitly instructed to delete messages.\"\n",
+    "    if log_changed: msg = await read_msgid(id, dname=dname)\n",
+    "    res = await call_endpa('rm_msg_', dname, raiseex=True, msid=id, json=True)\n",
+    "    if log_changed: await add_msg(f\"> Deleted #{id}\\n\\n```\\n{msg.content}\\n```\")\n",
+    "    return res\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6c959b",
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1558,7 +1291,44 @@
        "{'status': 'success'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "await del_msg(bmsg)\n",
+    "await del_msg(_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44cb1b2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f1e0ee6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```python\n",
+       "{'status': 'success'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'status': 'success'}"
+      ]
+     },
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1571,9 +1341,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da3525d7",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.851963+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_id = await _add_msg_unsafe('Hi', run=True, msg_type='prompt')"
@@ -1583,9 +1351,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b0077ef",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:00.934763+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1598,7 +1364,7 @@
        "{'status': 'success'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1611,9 +1377,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "023dcb74",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.001151+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1635,9 +1399,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "38875a12",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.032280+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1670,24 +1432,8 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4df69d72",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.066497+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'add_msg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m _id = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43madd_msg\u001b[49m(\u001b[33m'\u001b[39m\u001b[33mtesting\u001b[39m\u001b[33m'\u001b[39m)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'add_msg' is not defined"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "_id = await add_msg('testing')"
    ]
@@ -1696,9 +1442,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "05b509a7",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.098805+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_id = await update_msg(_id, content='toasting')"
@@ -1708,9 +1452,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8eaf1438",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.201829+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_id = await update_msg(_id, skipped=1)"
@@ -1720,31 +1462,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f6d1d6e1",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.290641+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "update_msg needs either a dict message with and id, or `id=`",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 3\u001b[39m",
-      "\u001b[32m      1\u001b[39m msg = \u001b[38;5;28;01mawait\u001b[39;00m read_msgid(_id)",
-      "\u001b[32m      2\u001b[39m msg[\u001b[33m'\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m'\u001b[39m] = \u001b[33m'\u001b[39m\u001b[33mtoasted\u001b[39m\u001b[33m'\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m update_msg(msg=msg)",
-      "",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 15\u001b[39m, in \u001b[36mupdate_msg\u001b[39m\u001b[34m(id, msg, dname, log_changed, **kwargs)\u001b[39m",
-      "\u001b[32m     13\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m msg: kwargs |= msg.get(\u001b[33m'\u001b[39m\u001b[33mmsg\u001b[39m\u001b[33m'\u001b[39m, msg)",
-      "\u001b[32m     14\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mid\u001b[39m: \u001b[38;5;28mid\u001b[39m = kwargs.pop(\u001b[33m'\u001b[39m\u001b[33mid\u001b[39m\u001b[33m'\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)",
-      "\u001b[32m---> \u001b[39m\u001b[32m15\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mid\u001b[39m: \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mupdate_msg needs either a dict message with and id, or `id=`\u001b[39m\u001b[33m\"\u001b[39m)",
-      "\u001b[32m     16\u001b[39m res = \u001b[38;5;28;01mawait\u001b[39;00m call_endpa(\u001b[33m'\u001b[39m\u001b[33mupdate_msg_\u001b[39m\u001b[33m'\u001b[39m, dname, \u001b[38;5;28mid\u001b[39m=\u001b[38;5;28mid\u001b[39m, log_changed=log_changed, **kwargs)",
-      "\u001b[32m     17\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m log_changed:",
-      "",
-      "\u001b[31mTypeError\u001b[39m: update_msg needs either a dict message with and id, or `id=`"
-     ]
+     "data": {
+      "text/plain": [
+       "'_51297401'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1757,22 +1485,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ae95747a",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.387541+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
        "```python\n",
-       "{'error': 'no message found'}\n",
+       "{'status': 'success'}\n",
        "```"
       ],
       "text/plain": [
-       "{'error': 'no message found'}"
+       "{'status': 'success'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1785,23 +1511,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ab9d75ec",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.460115+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'add_msg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m _edit_id = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43madd_msg\u001b[49m(\u001b[33m'\u001b[39m\u001b[33mThis message should be found.\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mThis is a multiline message.\u001b[39m\u001b[33m'\u001b[39m)",
-      "\u001b[32m      2\u001b[39m _edit_id",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'add_msg' is not defined"
-     ]
+     "data": {
+      "text/plain": [
+       "'_7ed8d056'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1813,16 +1533,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "22ecf206",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.509681+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "_edit_id = await add_msg('This message should be found.\\n\\nThis is a multiline message.')\n",
-      "_edit_id\n"
+      "This message should be found.\n",
+      "\n",
+      "This is a multiline message.\n"
      ]
     }
    ],
@@ -1834,21 +1553,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6d53e2dd",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.603090+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name '_edit_id' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28mprint\u001b[39m((\u001b[38;5;28;01mawait\u001b[39;00m read_msg(n=\u001b[32m0\u001b[39m, \u001b[38;5;28mid\u001b[39m=\u001b[43m_edit_id\u001b[49m, nums=\u001b[38;5;28;01mTrue\u001b[39;00m))[\u001b[33m'\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m'\u001b[39m])",
-      "",
-      "\u001b[31mNameError\u001b[39m: name '_edit_id' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This message should be found.\n",
+      "     2 │ \n",
+      "     3 │ This is a multiline message.\n"
      ]
     }
    ],
@@ -1860,21 +1573,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eda5f04b",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.638608+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name '_edit_id' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28mprint\u001b[39m((\u001b[38;5;28;01mawait\u001b[39;00m read_msg(n=\u001b[32m0\u001b[39m, \u001b[38;5;28mid\u001b[39m=\u001b[43m_edit_id\u001b[49m, nums=\u001b[38;5;28;01mTrue\u001b[39;00m, view_range=[\u001b[32m2\u001b[39m,\u001b[32m3\u001b[39m]))[\u001b[33m'\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m'\u001b[39m])",
-      "",
-      "\u001b[31mNameError\u001b[39m: name '_edit_id' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ \n",
+      "     3 │ This is a multiline message.\n"
      ]
     }
    ],
@@ -1886,9 +1592,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "316bd7a0",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.669921+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1904,10 +1608,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6e354677",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.719109+00:00"
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "1+1"
    ]
@@ -1916,9 +1629,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6e1c440e",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.746841+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "codeid = (await read_msg())['id']"
@@ -1928,9 +1639,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7084f544",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.837341+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1938,7 +1647,7 @@
        "'{\"status\":\"queued\"}'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1951,9 +1660,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "73025e57",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.931218+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1973,9 +1680,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "80def27e",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.961076+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -1994,9 +1699,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bc91a8d8",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:01.989834+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2004,7 +1707,7 @@
        "{'success': 'complete'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2017,9 +1720,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cb519067",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.087705+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tgt = (await read_msg())['id']"
@@ -2029,9 +1730,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "784f644c",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.183415+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2039,7 +1738,7 @@
        "{'success': 'complete'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2052,9 +1751,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "084f2a60",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.283744+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2062,7 +1759,7 @@
        "'1+1'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2076,9 +1773,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "527dc036",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.382014+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2091,7 +1786,7 @@
        "{'status': 'success'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2104,9 +1799,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "13e9163a",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.451030+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2130,9 +1823,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f2a4de16",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.479544+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2178,7 +1869,7 @@
        "}</script>"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2191,9 +1882,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f3d1e424",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.508397+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2206,9 +1895,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b90326a2",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.538421+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2225,7 +1912,7 @@
        "<div class=\"mermaid\">graph LR; A[Start] --&gt; B[Process]; B --&gt; C[End];</div>"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2282,9 +1969,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b220e29b",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.601570+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2302,9 +1987,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "90b55ef4",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.631955+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2322,9 +2005,7 @@
   {
    "cell_type": "markdown",
    "id": "ccfcb371",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### test header"
    ]
@@ -2333,10 +2014,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9eaf3f71",
-   "metadata": {
-    "hidden": true,
-    "time_run": "2026-02-10T21:02:02.660759+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hdid = (await read_msg())['id']"
@@ -2345,9 +2023,7 @@
   {
    "cell_type": "markdown",
    "id": "e59c6be8",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "test note"
    ]
@@ -2364,9 +2040,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c66d782b",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.753123+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2374,7 +2048,7 @@
        "{'success': 'complete'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2395,9 +2069,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1827e124",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.829937+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2418,29 +2090,8 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b90ff705",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.857549+00:00"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'add_msg' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m",
-      "\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m _id = \u001b[38;5;28;01mawait\u001b[39;00m url2note(\u001b[33m'\u001b[39m\u001b[33mhttps://www.example.org\u001b[39m\u001b[33m'\u001b[39m)",
-      "",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 11\u001b[39m, in \u001b[36murl2note\u001b[39m\u001b[34m(url, extract_section, selector, ai_img, split_re)\u001b[39m",
-      "\u001b[32m      9\u001b[39m res = read_url(url, as_md=\u001b[38;5;28;01mTrue\u001b[39;00m, extract_section=extract_section, selector=selector, ai_img=ai_img)",
-      "\u001b[32m     10\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m split_re: \u001b[38;5;28;01mreturn\u001b[39;00m [\u001b[38;5;28;01mawait\u001b[39;00m add_msg(s) \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m re.split(split_re, res, flags=re.MULTILINE) \u001b[38;5;28;01mif\u001b[39;00m s.strip()]",
-      "\u001b[32m---> \u001b[39m\u001b[32m11\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43madd_msg\u001b[49m(res)",
-      "",
-      "\u001b[31mNameError\u001b[39m: name 'add_msg' is not defined"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "_id = await url2note('https://www.example.org')"
    ]
@@ -2449,10 +2100,24 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fca3268c",
-   "metadata": {
-    "time_run": "2026-02-10T21:02:02.996520+00:00"
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```python\n",
+       "{'status': 'success'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'status': 'success'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await del_msg(_id)"
    ]
@@ -2479,7 +2144,23 @@
    "execution_count": null,
    "id": "1dd50b03",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```python\n",
+       "{'success': '\"aai-ws/dialoghelper/nbs/test_dialog\" is now running'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'success': '\"aai-ws/dialoghelper/nbs/test_dialog\" is now running'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await create_dialog('test_dialog')"
    ]
@@ -2505,7 +2186,23 @@
    "execution_count": null,
    "id": "de14cbc3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```python\n",
+       "{'success': 'deleted \"/Users/erikgaas/aai-ws/dialoghelper/nbs/test_dialog\"'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'success': 'deleted \"/Users/erikgaas/aai-ws/dialoghelper/nbs/test_dialog\"'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await rm_dialog('test_dialog')"
    ]
@@ -2620,7 +2317,18 @@
    "execution_count": null,
    "id": "10a14307",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': 'Inserted text at line _7ed8d056 content'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await msg_insert_line(_edit_id, 0, 'This should go to the first line')\n",
     "await msg_insert_line(_edit_id, 3, 'This should go to the 4th line')\n",
@@ -2632,7 +2340,20 @@
    "execution_count": null,
    "id": "53264093",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This should go to the first line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ This is a multiline message.\n",
+      "     6 │ This should go to the last line\n"
+     ]
+    }
+   ],
    "source": [
     "print((await read_msg(n=0, id=_edit_id, nums=True))['content'])"
    ]
@@ -2664,7 +2385,18 @@
    "execution_count": null,
    "id": "7fb271dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': 'Replaced text in message _7ed8d056 content'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await msg_str_replace(_edit_id, 'This should go to the first line', 'This should go to the 1st line')"
    ]
@@ -2674,7 +2406,26 @@
    "execution_count": null,
    "id": "fe526375",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'function'> True\n",
+      "(id: str, x: int, y: str)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"got myid (42, 'hello') {}\""
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import asyncio\n",
     "from fastcore.meta import splice_sig\n",
@@ -2696,7 +2447,20 @@
    "execution_count": null,
    "id": "fab1351f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ This is a multiline message.\n",
+      "     6 │ This should go to the last line\n"
+     ]
+    }
+   ],
    "source": [
     "print((await read_msg(n=0, id=_edit_id, nums=True))['content'])"
    ]
@@ -2733,7 +2497,18 @@
    "execution_count": null,
    "id": "baed4dec",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': 'Replaced all strings in message _7ed8d056 content'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await msg_strs_replace(_edit_id, ['This is a multiline message.', 'This should go to the last line'], ['5th line', 'last line'])"
    ]
@@ -2743,7 +2518,20 @@
    "execution_count": null,
    "id": "8d1ff40a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ This message should be found.\n",
+      "     3 │ \n",
+      "     4 │ This should go to the 4th line\n",
+      "     5 │ 5th line\n",
+      "     6 │ last line\n"
+     ]
+    }
+   ],
    "source": [
     "print((await read_msg(n=0, id=_edit_id, nums=True))['content'])"
    ]
@@ -2794,7 +2582,18 @@
    "execution_count": null,
    "id": "a087b570",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': 'Replaced lines in message _7ed8d056 content'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await msg_replace_lines(_edit_id, 2, 4,'line 2\\nline 3\\nline 4\\n')"
    ]
@@ -2804,7 +2603,20 @@
    "execution_count": null,
    "id": "86e28340",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ line 2\n",
+      "     3 │ line 3\n",
+      "     4 │ line 4\n",
+      "     5 │ 5th line\n",
+      "     6 │ last line\n"
+     ]
+    }
+   ],
    "source": [
     "print((await read_msg(n=0, id=_edit_id, nums=True))['content'])"
    ]
@@ -2836,7 +2648,18 @@
    "execution_count": null,
    "id": "fd38ca34",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': 'Deleted lines in message _7ed8d056 content'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await msg_del_lines(_edit_id, 2, 4)"
    ]
@@ -2846,7 +2669,17 @@
    "execution_count": null,
    "id": "1c2dcb37",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 │ This should go to the 1st line\n",
+      "     2 │ 5th line\n",
+      "     3 │ last line\n"
+     ]
+    }
+   ],
    "source": [
     "print((await read_msg(n=0, id=_edit_id, nums=True))['content'])"
    ]
@@ -2856,7 +2689,23 @@
    "execution_count": null,
    "id": "26889752",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```python\n",
+       "{'status': 'success'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'status': 'success'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await del_msg(_edit_id)"
    ]
@@ -2985,7 +2834,19 @@
    "execution_count": null,
    "id": "faeb0863",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(\"'hello world'\",\n",
+       " Range(start=Pos(line=0, col=6, index=6), end=Pos(line=0, col=19, index=19)))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "node = ast_py(\"print('hello world')\")\n",
     "stmt = node.find(pattern=\"print($A)\")\n",
@@ -3042,7 +2903,27 @@
    "execution_count": null,
    "id": "f7227c1e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('xpost(url, data=data, headers=headers)',\n",
+       "  {'A': {'text': 'url',\n",
+       "    'range': {'byteOffset': {'start': 8089, 'end': 8092},\n",
+       "     'start': {'line': 180, 'column': 30},\n",
+       "     'end': {'line': 180, 'column': 33}}},\n",
+       "   'B': {'text': 'data',\n",
+       "    'range': {'byteOffset': {'start': 8099, 'end': 8103},\n",
+       "     'start': {'line': 180, 'column': 40},\n",
+       "     'end': {'line': 180, 'column': 44}}}},\n",
+       "  'dialoghelper/core.py')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "res = ast_grep(r\"xpost($A, data=$B, $$$)\", '..')\n",
     "[(o['text'],o['metaVariables']['single'],o['file']) for o in res]"
@@ -3277,7 +3158,18 @@
    "execution_count": null,
    "id": "3ab7586f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://gist.github.com/jph00/e7cfd4ded593e8ef6217e78a0131960c'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "gistid = 'jph00/e7cfd4ded593e8ef6217e78a0131960c'\n",
     "gist = load_gist(gistid)\n",
@@ -3303,7 +3195,18 @@
    "execution_count": null,
    "id": "ea33969d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"This is a test module which makes some simple tools available.\"\n",
+      "__all__ = [\"hi\",\"whoami\"]\n",
+      "\n",
+      "testfoo=…\n"
+     ]
+    }
+   ],
    "source": [
     "gfile = gist_file(gistid)\n",
     "print(gfile.content[:100]+\"…\")"
@@ -3384,7 +3287,15 @@
    "execution_count": null,
    "id": "a952258c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- &`hi`: Say hi to `who`\n"
+     ]
+    }
+   ],
    "source": [
     "print(mk_toollist([hi]))"
    ]
@@ -3426,7 +3337,18 @@
    "execution_count": null,
    "id": "aefee238",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'testbar'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import_gist(gistid)\n",
     "importtest.testfoo"
@@ -3437,7 +3359,18 @@
    "execution_count": null,
    "id": "4a4f7f89",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Import gist directly from string without saving to disk'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import_gist.__doc__"
    ]
@@ -3447,7 +3380,18 @@
    "execution_count": null,
    "id": "e80a7944",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'testbar'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import_gist(gistid, import_wildcard=True)\n",
     "importtest.testfoo"
@@ -3458,7 +3402,18 @@
    "execution_count": null,
    "id": "573abb48",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello Sarah'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "hi(\"Sarah\")"
    ]
@@ -3468,7 +3423,18 @@
    "execution_count": null,
    "id": "392dc090",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['hi', 'whoami']"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "importtest.__all__"
    ]
@@ -3512,10 +3478,7 @@
    ]
   }
  ],
- "metadata": {
-  "solveit_dialog_mode": "learning",
-  "solveit_ver": 2
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/nbs/test_dialog.ipynb
+++ b/nbs/test_dialog.ipynb
@@ -1,9 +1,0 @@
-{
- "cells": [],
- "metadata": {
-  "solveit_dialog_mode": "learning",
-  "solveit_ver": 2
- },
- "nbformat": 4,
- "nbformat_minor": 5
-}


### PR DESCRIPTION
## Changes

- `_add_msg_unsafe` now has all explicit params with defaults (`i_collapsed=0`, `o_collapsed=0`, etc.) instead of `@delegates(add_msg)` + `**kwargs`
- `add_msg` delegates to `_add_msg_unsafe` with `run=False` — single source of truth for defaults
- Moved `_add_msg_unsafe` above `add_msg` in notebook (must be defined first)

## Why

When creating messages via `solveit_client` or `_add_msg_unsafe` without passing all kwargs, params like `i_collapsed` were `Unset` (not `0`), causing a `TypeError: can't multiply sequence by non-int of type 'NoneType'` in `cards.py`.

Previously `@delegates(add_msg)` on `_add_msg_unsafe` copied param *names* but not *default values*, so they simply weren't sent to `add_relative_`.

Related: #119 (Alexis's earlier attempt at this fix)