### PR TITLE
`safe_type` type hint

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -321,7 +321,7 @@ class RunPython:
 run_python = RunPython()
 
 # %% ../nbs/00_core.ipynb #2303931f
-def safe_type(o):
+def safe_type(o:object):
     "Same as `type(o)`"
     return type(o)
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -874,7 +874,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def safe_type(o):\n",
+    "def safe_type(o:object):\n",
     "    \"Same as `type(o)`\"\n",
     "    return type(o)"
    ]


### PR DESCRIPTION
Add `object` type hint to `safe_type`'s `o` parameter. Without the annotation, toolslm's `get_schema` raised `TypeError: Missing type` when `safe_type` was registered as a tool.

**Depends on:** AnswerDotAI/toolslm#76 — without that fix, the `object` type hint itself causes an `AttributeError` in `_handle_type`.

<img width="1185" height="231" alt="image" src="https://github.com/user-attachments/assets/983a2a36-f23c-4b29-a9df-85589dd98a31" />

Fixes #130