### PR TITLE
Add explicit async_run param to _add_msg_unsafe

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -560,6 +560,7 @@ async def _add_msg_unsafe(
     placement:str='add_after', # Can be 'at_start' or 'at_end', and for default dname can also be 'add_after' or 'add_before'
     id:str=None, # id of message that placement is relative to (if None, uses current message)
     dname:str='', # Dialog to get info for; defaults to current dialog (`run` only has a effect if dialog is currently running)
+    async_run:bool=False, # Run prompt asynchronously (starts immediately, doesn't block run queue)?
     **kwargs
 )->str: # Message ID of newly created message
     """Add/update a message to the queue to show after code execution completes, and optionally run it.
@@ -569,7 +570,7 @@ async def _add_msg_unsafe(
     _diff_dialog(placement not in ('at_start','at_end'), dname,
         "`id` or `placement='at_end'`/`placement='at_start'` must be provided when target dialog is different", id=id)    
     if placement not in ('at_start','at_end') and not id: id = find_msg_id()
-    return await call_endpa('add_relative_', dname, content=content, placement=placement, id=id, **kwargs)
+    return await call_endpa('add_relative_', dname, content=content, placement=placement, id=id, async_run=async_run, **kwargs)
 
 # %% ../nbs/00_core.ipynb #3ad14786
 @llmtool(dname=dname_doc)

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1566,6 +1566,7 @@
     "    placement:str='add_after', # Can be 'at_start' or 'at_end', and for default dname can also be 'add_after' or 'add_before'\n",
     "    id:str=None, # id of message that placement is relative to (if None, uses current message)\n",
     "    dname:str='', # Dialog to get info for; defaults to current dialog (`run` only has a effect if dialog is currently running)\n",
+    "    async_run:bool=False, # Run prompt asynchronously (starts immediately, doesn't block run queue)?\n",
     "    **kwargs\n",
     ")->str: # Message ID of newly created message\n",
     "    \"\"\"Add/update a message to the queue to show after code execution completes, and optionally run it.\n",
@@ -1575,7 +1576,7 @@
     "    _diff_dialog(placement not in ('at_start','at_end'), dname,\n",
     "        \"`id` or `placement='at_end'`/`placement='at_start'` must be provided when target dialog is different\", id=id)    \n",
     "    if placement not in ('at_start','at_end') and not id: id = find_msg_id()\n",
-    "    return await call_endpa('add_relative_', dname, content=content, placement=placement, id=id, **kwargs)"
+    "    return await call_endpa('add_relative_', dname, content=content, placement=placement, id=id, async_run=async_run, **kwargs)"
    ]
   },
   {


### PR DESCRIPTION
Adds `async_run:bool=False` as an explicit parameter to `_add_msg_unsafe` so it's visible in the signature and docs.

Previously it worked via `**kwargs` but wasn't discoverable. Now it's a first-class parameter that gets passed through to `add_relative_`.

Companion to AnswerDotAI/solveit#1534 which refactors async prompt execution.