### PR TITLE
fix cp/paste/toggle header silent failure

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -694,6 +694,7 @@ async def copy_msg(
     "Add `ids` to clipboard."
     id,*_ = ids.split(',')
     res = await call_endpa('msg_clipboard_', dname, ids=ids, id=id, cmd='cut' if cut else 'copy')
+    if not res: return {'error': f'Dialog: {dname} is not running!'}
     return {'success':'complete'}
 
 
@@ -706,6 +707,7 @@ async def paste_msg(
 ):
     "Paste clipboard msg(s) after/before the current selected msg (id)."
     res = await call_endpa('msg_paste_', dname, id=id, after=after)
+    if not res: return {'error': f'Dialog: {dname} is not running!'}
     return {'success':'complete'}
 
 
@@ -738,8 +740,8 @@ async def toggle_header(
 ):
     "Toggle collapsed header state for `id`"
     res = await call_endpa('toggle_header_collapse_', dname, id=id)
+    if not res: return {'error': f'Dialog: {dname} is not running!'}
     return {'success':'complete'}
-
 
 # %% ../nbs/00_core.ipynb #90b55ef4
 @llmtool

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -86,7 +86,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastcore import tools"
+    "from fastcore import tools\n",
+    "from fastcore.test import *"
    ]
   },
   {
@@ -1415,7 +1416,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'id': '_5a8db1de', 'is_exported': 0, 'content': 'def f(): warnings.warn(\\'a warning\\')\\nallow(\\'f\\')\\nawait python(\\'print(\"asdf\"); f(); 1+1\\')', 'output': '{&#x27;stdout&#x27;: &#x27;asdf\\\\n&#x27;, &#x27;warnings&#x27;: &#x27;UserWarning: a warning&#x27;, &#x27;result&#x27;: 2}', 'msg_type': 'code'}, {'id': '_8ce548d6', 'is_exported': 0, 'content': '1+1', 'output': '2', 'msg_type': 'code'}, {'id': '_44cb1b2a', 'is_exported': 0, 'content': \"_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')\", 'output': '', 'msg_type': 'code'}, {'id': '_6e354677', 'is_exported': 0, 'content': '1+1', 'output': '2', 'msg_type': 'code'}]"
+       "[{'id': '_5a8db1de', 'is_exported': 0, 'content': 'def f(): warnings.warn(\\'a warning\\')\\nallow(\\'f\\')\\nawait python(\\'print(\"asdf\"); f(); 1+1\\')', 'output': '{&#x27;stdout&#x27;: &#x27;asdf\\\\n&#x27;, &#x27;warnings&#x27;: &#x27;UserWarning: a warning&#x27;, &#x27;result&#x27;: 2}', 'msg_type': 'code'}, {'id': '_8ce548d6', 'is_exported': 0, 'content': '1+1', 'output': '2', 'msg_type': 'code'}, {'id': '_44cb1b2a', 'is_exported': 0, 'content': \"_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')\", 'output': '', 'msg_type': 'code'}, {'id': '_6e354677', 'is_exported': 0, 'content': '1+1', 'output': '', 'msg_type': 'code'}]"
       ]
      },
      "execution_count": null,
@@ -1442,7 +1443,7 @@
        "```html\n",
        "<msgs><code id=\"_5a8db1de\"><source>def f(): warnings.warn('a warning')\n",
        "allow('f')\n",
-       "await python('print(\"asdf\"); f(); 1+1')<out>{&#x27;stdout&#x27;: &#x27;asdf\\n&#x27;, &#x27;warnings&#x27;: &#x27;UserWarning: a warning&#x27;, &#x27;result&#x27;: 2}</out></code><code id=\"_8ce548d6\"><source>1+1<out>2</out></code><code id=\"_44cb1b2a\">_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')</code><code id=\"_6e354677\"><source>1+1<out>2</out></code></msgs>\n",
+       "await python('print(\"asdf\"); f(); 1+1')<out>{&#x27;stdout&#x27;: &#x27;asdf\\n&#x27;, &#x27;warnings&#x27;: &#x27;UserWarning: a warning&#x27;, &#x27;result&#x27;: 2}</out></code><code id=\"_8ce548d6\"><source>1+1<out>2</out></code><code id=\"_44cb1b2a\">_id = await _add_msg_unsafe('1+1', run=True, msg_type='code')</code><code id=\"_6e354677\">1+1</code></msgs>\n",
        "```\n",
        "\n",
        "</div>"
@@ -1689,7 +1690,140 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "testing\n"
+      "@llmtool\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@delegates(_add_msg_unsafe, but=['content','msg_type','run_mode'])\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "async def add_prompt(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    content:str,    # Prompt to run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    dname:str=None, # Dialog to run prompt in; defaults to current dialog\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    msg_id:str=None, # Message id to place prompt after (if None, places at end)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    wait:bool=True, # Wait for and return response?\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    poll:float=0.5, # Frequency of polling to check for completion\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    placement:str='', # Location to place message, defaults to 'at_end' if no msg_id\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    **kwargs\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    \"Run a prompt and, if `wait`, wait for and return the response text\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    assert not (wait and not dname), \"Can not wait in current dialog\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    if not placement: placement = 'add_after' if msg_id else 'at_end'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    msg_id = await _add_msg_unsafe(content, msg_type='prompt', run_mode='run', dname=dname, placement=placement, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    if not wait: return msg_id\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    while True:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        res = await read_msgid(msg_id, dname=dname)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        if not res.get('run', False): return res['output']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        await asyncio.sleep(poll)\n"
      ]
     }
    ],
@@ -1767,11 +1901,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -1804,11 +1933,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -1840,11 +1964,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -1952,7 +2071,7 @@
     {
      "data": {
       "text/plain": [
-       "'_60134000'"
+       "'_47526d6d'"
       ]
      },
      "execution_count": null,
@@ -1974,11 +2093,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -2001,7 +2115,7 @@
     {
      "data": {
       "text/plain": [
-       "'_c3ec08ba'"
+       "'_b10475a4'"
       ]
      },
      "execution_count": null,
@@ -2012,6 +2126,29 @@
    "source": [
     "_edit_id = await add_msg('This message should be found.\\n\\nThis is a multiline message.')\n",
     "_edit_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "488460a3",
+   "metadata": {},
+   "source": [
+    "This should go to the first line\n",
+    "This message should be found.\n",
+    "\n",
+    "This should go to the 4th line\n",
+    "This is a multiline message.\n",
+    "This should go to the last line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acbd77c2",
+   "metadata": {},
+   "source": [
+    "This message should be found.\n",
+    "\n",
+    "This is a multiline message."
    ]
   },
   {
@@ -2188,6 +2325,7 @@
     "    \"Add `ids` to clipboard.\"\n",
     "    id,*_ = ids.split(',')\n",
     "    res = await call_endpa('msg_clipboard_', dname, ids=ids, id=id, cmd='cut' if cut else 'copy')\n",
+    "    if not res: return {'error': f'Dialog: {dname} is not running!'}\n",
     "    return {'success':'complete'}\n"
    ]
   },
@@ -2207,6 +2345,7 @@
     "):\n",
     "    \"Paste clipboard msg(s) after/before the current selected msg (id).\"\n",
     "    res = await call_endpa('msg_paste_', dname, id=id, after=after)\n",
+    "    if not res: return {'error': f'Dialog: {dname} is not running!'}\n",
     "    return {'success':'complete'}\n"
    ]
   },
@@ -2229,6 +2368,16 @@
    ],
    "source": [
     "await copy_msg(codeid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dc798ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq((await copy_msg('_fake', dname='/dlg/nonexistent'))['error'], 'Dialog: /dlg/nonexistent is not running!')"
    ]
   },
   {
@@ -2265,6 +2414,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "75b94d4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq((await paste_msg('_fake', dname='/dlg/nonexistent'))['error'], 'Dialog: /dlg/nonexistent is not running!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "084f2a60",
    "metadata": {},
    "outputs": [
@@ -2292,11 +2451,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -2495,7 +2649,8 @@
     "):\n",
     "    \"Toggle collapsed header state for `id`\"\n",
     "    res = await call_endpa('toggle_header_collapse_', dname, id=id)\n",
-    "    return {'success':'complete'}\n"
+    "    if not res: return {'error': f'Dialog: {dname} is not running!'}\n",
+    "    return {'success':'complete'}"
    ]
   },
   {
@@ -2573,6 +2728,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd7db367",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq((await toggle_header('_fake', dname='/dlg/nonexistent'))['error'], 'Dialog: /dlg/nonexistent is not running!')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "96bf4afb",
    "metadata": {},
@@ -2619,11 +2784,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -2662,11 +2822,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'success': '\"aai-ws/dialoghelper/nbs/test_dialog\" is now running'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'success': '\"aai-ws/dialoghelper/nbs/test_dialog\" is now running'}"
       ]
@@ -2704,13 +2859,8 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'success': 'deleted \"/Users/jhoward/aai-ws/dialoghelper/nbs/test_dialog\"'}\n",
-       "```"
-      ],
       "text/plain": [
-       "{'success': 'deleted \"/Users/jhoward/aai-ws/dialoghelper/nbs/test_dialog\"'}"
+       "{'success': 'deleted \"/Users/keremturgutlu/aai-ws/dialoghelper/nbs/test_dialog\"'}"
       ]
      },
      "execution_count": null,
@@ -2836,7 +2986,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'Inserted text at line _928096c0 content'}"
+       "{'success': 'Inserted text at line _b10475a4 content'}"
       ]
      },
      "execution_count": null,
@@ -2860,11 +3010,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the first line\n",
-      "     2 │ This message should be found.\n",
-      "     3 │ \n",
-      "     4 │ This should go to the 4th line\n",
-      "     5 │ This is a multiline message.\n",
+      "     1 │ This should go to the first line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ This message should be found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     3 │ \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     4 │ This should go to the 4th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     5 │ This is a multiline message.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     6 │ This should go to the last line\n"
      ]
     }
@@ -2904,7 +3084,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'Replaced text in message _928096c0 content'}"
+       "{'success': 'Replaced text in message _b10475a4 content'}"
       ]
      },
      "execution_count": null,
@@ -2926,7 +3106,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'function'> True\n",
+      "<class 'function'> True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "(id: str, x: int, y: str)\n"
      ]
     },
@@ -2967,11 +3153,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n",
-      "     2 │ This message should be found.\n",
-      "     3 │ \n",
-      "     4 │ This should go to the 4th line\n",
-      "     5 │ This is a multiline message.\n",
+      "     1 │ This should go to the 1st line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ This message should be found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     3 │ \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     4 │ This should go to the 4th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     5 │ This is a multiline message.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     6 │ This should go to the last line\n"
      ]
     }
@@ -3016,7 +3232,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'Replaced all strings in message _928096c0 content'}"
+       "{'success': 'Replaced all strings in message _b10475a4 content'}"
       ]
      },
      "execution_count": null,
@@ -3038,11 +3254,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n",
-      "     2 │ This message should be found.\n",
-      "     3 │ \n",
-      "     4 │ This should go to the 4th line\n",
-      "     5 │ 5th line\n",
+      "     1 │ This should go to the 1st line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ This message should be found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     3 │ \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     4 │ This should go to the 4th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     5 │ 5th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     6 │ last line\n"
      ]
     }
@@ -3101,7 +3347,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'Replaced lines in message _928096c0 content'}"
+       "{'success': 'Replaced lines in message _b10475a4 content'}"
       ]
      },
      "execution_count": null,
@@ -3123,11 +3369,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n",
-      "     2 │ line 2\n",
-      "     3 │ line 3\n",
-      "     4 │ line 4\n",
-      "     5 │ 5th line\n",
+      "     1 │ This should go to the 1st line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ line 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     3 │ line 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     4 │ line 4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     5 │ 5th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     6 │ last line\n"
      ]
     }
@@ -3167,7 +3443,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'Deleted lines in message _928096c0 content'}"
+       "{'success': 'Deleted lines in message _b10475a4 content'}"
       ]
      },
      "execution_count": null,
@@ -3189,8 +3465,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     1 │ This should go to the 1st line\n",
-      "     2 │ 5th line\n",
+      "     1 │ This should go to the 1st line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     2 │ 5th line\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     3 │ last line\n"
      ]
     }
@@ -3207,11 +3495,6 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "```python\n",
-       "{'status': 'success'}\n",
-       "```"
-      ],
       "text/plain": [
        "{'status': 'success'}"
       ]
@@ -3326,14 +3609,14 @@
      "data": {
       "text/plain": [
        "[('xpost(url, data=data, headers=headers)',\n",
-       "  {'A': {'text': 'url',\n",
-       "    'range': {'byteOffset': {'start': 6370, 'end': 6373},\n",
-       "     'start': {'line': 135, 'column': 30},\n",
-       "     'end': {'line': 135, 'column': 33}}},\n",
-       "   'B': {'text': 'data',\n",
-       "    'range': {'byteOffset': {'start': 6380, 'end': 6384},\n",
+       "  {'B': {'text': 'data',\n",
+       "    'range': {'byteOffset': {'start': 6402, 'end': 6406},\n",
        "     'start': {'line': 135, 'column': 40},\n",
-       "     'end': {'line': 135, 'column': 44}}}},\n",
+       "     'end': {'line': 135, 'column': 44}}},\n",
+       "   'A': {'text': 'url',\n",
+       "    'range': {'byteOffset': {'start': 6392, 'end': 6395},\n",
+       "     'start': {'line': 135, 'column': 30},\n",
+       "     'end': {'line': 135, 'column': 33}}}},\n",
        "  'dialoghelper/core.py')]"
       ]
      },
@@ -3618,9 +3901,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"This is a test module which makes some simple tools available.\"\n",
-      "__all__ = [\"hi\",\"whoami\"]\n",
-      "\n",
+      "\"This is a test module which makes some simple tools available.\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "__all__ = [\"hi\",\"whoami\"]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "testfoo=…\n"
      ]
     }


### PR DESCRIPTION
`copy_msg`, `paste_msg`, and `toggle_header` silently returned `{'success': 'complete'}` when the target dialog wasn't running. The `call_endpa()` response (empty string on failure) was ignored.

Now checks `if not res` before returning success and returns `{'error': f'Dialog: {dname} is not running!'}` instead.

Fixes #140