### PR TITLE
Remove unused run:bool param from _add_msg - so ai doesn't get confused.

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -351,7 +351,6 @@ Placements = str_enum('Placements', 'add_after', 'add_before', 'at_start', 'at_e
 
 # %% ../nbs/00_core.ipynb #5093cfe4
 def _add_msg(
-    run:bool=False, # For prompts, send it to the AI; for code, execute it (*DANGEROUS -- be careful of what you run!)
     msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'
     output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array
     time_run: str | None = '', # When was message executed

--- a/dialoghelper/dialoghelper
+++ b/dialoghelper/dialoghelper
@@ -1,0 +1,1 @@
+/app/data/repos/dialoghelper/dialoghelper

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1131,7 +1131,6 @@
    "source": [
     "#| export\n",
     "def _add_msg(\n",
-    "    run:bool=False, # For prompts, send it to the AI; for code, execute it (*DANGEROUS -- be careful of what you run!)\n",
     "    msg_type: str='note', # Message type, can be 'code', 'note', or 'prompt'\n",
     "    output:str='', # Prompt/code output; Code outputs must be .ipynb-compatible JSON array\n",
     "    time_run: str | None = '', # When was message executed\n",


### PR DESCRIPTION
The `run:bool=False` parameter in `_add_msg` is not used in add_relative_ anymore. But llm it is valid param, and uses add_msg(..., run=True) instead of fences. 

<img width="1115" height="558" alt="Screenshot 2026-02-23 at 13 09 45" src="https://github.com/user-attachments/assets/57ddc6bb-c05e-4578-91b1-3422fc77396d" />

I haven't exposed run_mode as It has description in _add_msg_unsafe already
