### PR TITLE
create dlg with optional template

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -593,10 +593,11 @@ async def url2note(
 @llmtool
 async def create_or_run_dialog(
     name:str, # Name/path of the dialog (relative to current dialog's folder, or absolute if starts with '/')
+    template:bool=True, # Include TEMPLATE.ipynb files when creating a new dialog
 ):
     "Create a new dialog, or set an existing one running"
     name = find_dname(name).lstrip('/')
-    return await call_endpa('create_dialog_', name=name, json=True)
+    return await call_endpa('create_dialog_', name=name, template=template, json=True)
 
 # %% ../nbs/00_core.ipynb #80433dd1
 @llmtool

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2224,10 +2224,11 @@
     "@llmtool\n",
     "async def create_or_run_dialog(\n",
     "    name:str, # Name/path of the dialog (relative to current dialog's folder, or absolute if starts with '/')\n",
+    "    template:bool=True, # Include TEMPLATE.ipynb files when creating a new dialog\n",
     "):\n",
     "    \"Create a new dialog, or set an existing one running\"\n",
     "    name = find_dname(name).lstrip('/')\n",
-    "    return await call_endpa('create_dialog_', name=name, json=True)"
+    "    return await call_endpa('create_dialog_', name=name, template=template, json=True)"
    ]
   },
   {


### PR DESCRIPTION
Add `template:bool=True` param to `create_or_run_dialog` to optionally exclude TEMPLATE.ipynb files when creating a new dialog.

## Changes

- `create_or_run_dialog(name, template=True)`: new param forwarded to solveit's `create_dialog_` endpoint via `call_endpa`

Depends on AnswerDotAI/solveit#1603