### PR TITLE
Add `r` (read file) support to `msg_exhash` + `output` param for `msg_lnhashview`

### DIFF
--- a/dialoghelper/exhash.py
+++ b/dialoghelper/exhash.py
@@ -6,15 +6,19 @@ __all__ = ['msg_lnhashview', 'msg_exhash', 'file_lnhashview', 'file_exhash']
 # %% ../nbs/04_exhash.ipynb #d6291515
 from .core import *
 from exhash import *
+from tempfile import TemporaryDirectory
+from fastcore.foundation import working_directory
+from pathlib import Path
 
 # %% ../nbs/04_exhash.ipynb #c7a53c95
-async def msg_lnhashview(id:str):
-    "Show lnhash-addressed lines of a message"
+async def msg_lnhashview(id:str, output:bool=False):
+    "Show lnhash-addressed lines of a message's content or output"
     msg = await read_msgid(id=id)
-    return '\n'.join(lnhashview(msg['content']))
+    txt = msg['output'] if output else msg['content']
+    return '\n'.join(lnhashview(txt))
 
 # %% ../nbs/04_exhash.ipynb #9bdae034
-async def msg_exhash(id:str, cmds:list):
+async def msg_exhash(id:str, cmds:list, ids:list[str]=None):
     """Verified line-addressed editor. Apply commands to msg `id` contents, return lnhashview(result).
     **NB**: *all* exhash commands *must* start with an address.
     The *only* allowed addresses are a single lnhash, or a pair separated by `,`. (I.e no `%`, `.`, etc.)
@@ -26,7 +30,7 @@ async def msg_exhash(id:str, cmds:list):
     Addressing:
       Single:   ``12|a3f2|cmd``
       Range:    ``12|a3f2|,15|b1c3|cmd``
-      Special:  ``0|0000|`` targets before line 1 (only with a or i)
+      Special:  ``0|0000|`` targets before line 1 (only with a, i, or r)
 
     Commands:
       s/pat/rep/[flags]  Substitute (regex). Flags: g=all, i=case-insensitive
@@ -43,11 +47,19 @@ async def msg_exhash(id:str, cmds:list):
       p                  Print (include in output without changing)
       g/pat/cmd          Global: run cmd on matching lines
       g!/pat/cmd         Inverted global (also v/pat/cmd)
+      r filepath         Read file contents and insert after address
 
-    `cmds` is a required list of command strings. For `a`/`i`/`c`, include the text block in the same command string after a newline."""
-    msg = await read_msgid(id=id)
-    txt = msg['content']
-    res = exhash(txt, cmds)
+    `cmds` is a required list of command strings. For `a`/`i`/`c`, include the text block in the same command string after a newline.
+    `ids` is an optional list of message ids whose content will be written to temp files (as `{id}.txt`) so `r` commands can reference them."""
+    all_ids = [id] + (ids or [])
+    with TemporaryDirectory(prefix='exhash_') as tmpdir: # Mirror messages to files to allow r filepath to work
+      with working_directory(tmpdir):
+        tmpdir = Path(tmpdir)
+        for mid in all_ids:
+            msg = await read_msgid(id=mid)
+            (tmpdir / f'{mid}.txt').write_text(msg['content'])
+        txt = (tmpdir / f'{id}.txt').read_text()
+        res = exhash(txt, cmds)
     res = '\n'.join(res['lines'])
     upres = await update_msg(id=id, content=res)
     assert upres.startswith('_'), f"Message update failed: {upres}"

--- a/nbs/04_exhash.ipynb
+++ b/nbs/04_exhash.ipynb
@@ -19,7 +19,10 @@
    "source": [
     "#| export\n",
     "from dialoghelper.core import *\n",
-    "from exhash import *"
+    "from exhash import *\n",
+    "from tempfile import TemporaryDirectory\n",
+    "from fastcore.foundation import working_directory\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -67,10 +70,11 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def msg_lnhashview(id:str):\n",
-    "    \"Show lnhash-addressed lines of a message\"\n",
+    "async def msg_lnhashview(id:str, output:bool=False):\n",
+    "    \"Show lnhash-addressed lines of a message's content or output\"\n",
     "    msg = await read_msgid(id=id)\n",
-    "    return '\\n'.join(lnhashview(msg['content']))"
+    "    txt = msg['output'] if output else msg['content']\n",
+    "    return '\\n'.join(lnhashview(txt))"
    ]
   },
   {
@@ -81,7 +85,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "async def msg_exhash(id:str, cmds:list):\n",
+    "async def msg_exhash(id:str, cmds:list, ids:list[str]=None):\n",
     "    \"\"\"Verified line-addressed editor. Apply commands to msg `id` contents, return lnhashview(result).\n",
     "    **NB**: *all* exhash commands *must* start with an address.\n",
     "    The *only* allowed addresses are a single lnhash, or a pair separated by `,`. (I.e no `%`, `.`, etc.)\n",
@@ -93,7 +97,7 @@
     "    Addressing:\n",
     "      Single:   ``12|a3f2|cmd``\n",
     "      Range:    ``12|a3f2|,15|b1c3|cmd``\n",
-    "      Special:  ``0|0000|`` targets before line 1 (only with a or i)\n",
+    "      Special:  ``0|0000|`` targets before line 1 (only with a, i, or r)\n",
     "\n",
     "    Commands:\n",
     "      s/pat/rep/[flags]  Substitute (regex). Flags: g=all, i=case-insensitive\n",
@@ -110,11 +114,19 @@
     "      p                  Print (include in output without changing)\n",
     "      g/pat/cmd          Global: run cmd on matching lines\n",
     "      g!/pat/cmd         Inverted global (also v/pat/cmd)\n",
+    "      r filepath         Read file contents and insert after address\n",
     "\n",
-    "    `cmds` is a required list of command strings. For `a`/`i`/`c`, include the text block in the same command string after a newline.\"\"\"\n",
-    "    msg = await read_msgid(id=id)\n",
-    "    txt = msg['content']\n",
-    "    res = exhash(txt, cmds)\n",
+    "    `cmds` is a required list of command strings. For `a`/`i`/`c`, include the text block in the same command string after a newline.\n",
+    "    `ids` is an optional list of message ids whose content will be written to temp files (as `{id}.txt`) so `r` commands can reference them.\"\"\"\n",
+    "    all_ids = [id] + (ids or [])\n",
+    "    with TemporaryDirectory(prefix='exhash_') as tmpdir: # Mirror messages to files to allow r filepath to work\n",
+    "      with working_directory(tmpdir):\n",
+    "        tmpdir = Path(tmpdir)\n",
+    "        for mid in all_ids:\n",
+    "            msg = await read_msgid(id=mid)\n",
+    "            (tmpdir / f'{mid}.txt').write_text(msg['content'])\n",
+    "        txt = (tmpdir / f'{id}.txt').read_text()\n",
+    "        res = exhash(txt, cmds)\n",
     "    res = '\\n'.join(res['lines'])\n",
     "    upres = await update_msg(id=id, content=res)\n",
     "    assert upres.startswith('_'), f\"Message update failed: {upres}\"\n",


### PR DESCRIPTION
Builds on the new `r` command added to exhash (AnswerDotAI/exhash#5) to enable cross-message copy-paste.

## Changes

- **`msg_lnhashview`**: Added `output: bool = False` param to view lnhash of prompt outputs, not just content
- **`msg_exhash`**: Added `ids: list[str] = None` param — writes listed messages to temp files so `r` commands can reference them as `{id}.txt`

## Usage

```python
# Cross-message copy: read contents of _src into _dest after line 3
await msg_exhash('_dest', ['3|a3f2|r _src.txt'], ids=['_src'])

# View hashes of prompt output
await msg_lnhashview('_prompt_id', output=True)
```

## Why

Enables efficient cross-message editing — instead of retranscribing content, the AI can `r` from one message into another. Combined with batch commands, this significantly reduces token usage and round-trips.