### PR TITLE
fix: reverse split order in url2note for correct message ordering

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -590,7 +590,7 @@ async def url2note(
 ):
     "Read URL as markdown, and add note(s) below current message with the result"
     res = read_url(url, as_md=True, extract_section=extract_section, selector=selector, ai_img=ai_img)
-    if split_re: return [await add_msg(s) for s in re.split(split_re, res, flags=re.MULTILINE) if s.strip()]
+    if split_re: return [await add_msg(s) for s in re.split(split_re, res, flags=re.MULTILINE)[::-1] if s.strip()]
     return await add_msg(res)
 
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2135,7 +2135,7 @@
     "):\n",
     "    \"Read URL as markdown, and add note(s) below current message with the result\"\n",
     "    res = read_url(url, as_md=True, extract_section=extract_section, selector=selector, ai_img=ai_img)\n",
-    "    if split_re: return [await add_msg(s) for s in re.split(split_re, res, flags=re.MULTILINE) if s.strip()]\n",
+    "    if split_re: return [await add_msg(s) for s in re.split(split_re, res, flags=re.MULTILINE)[::-1] if s.strip()]\n",
     "    return await add_msg(res)\n"
    ]
   },


### PR DESCRIPTION
Small fix. Here's a demo of the broken behavior & fix:

https://github.com/user-attachments/assets/2f7a471c-5d45-4ffd-98ea-ab6c6d6bb92b


