### PR TITLE
Unified dialog_link param name to dname

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -1219,17 +1219,19 @@ If the user wants more info, give them a link to https://gist.github.com/jph00/{
 # %% ../nbs/00_core.ipynb #70ec67db
 @llmtool
 def dialog_link(
-    path:str='', # Path to dialog (e.g. '/aai-ws/dialoghelper/nbs/00_core'), defaults to current dialog
+    dname:str='', # Dialog to link to (relative to current dialog's folder, or absolute if starts with '/'); empty for in-page anchor link
     msg_id:str=None # Optional message id to scroll to
 ):
     """Return an IPython HTML link to open a dialog in Solveit.
     After calling this tool, output the resulting HTML anchor tag exactly as returned—do not wrap in a fenced code block or convert to markdown link format."""
-    if not (path or msg_id): return 'err: no path or id'
-    path = path.removeprefix('/')
+    if not (dname or msg_id): return 'err: no dname or msg_id'
     url = ''
-    if path: url += f"/dialog_?{urlencode({'name': path})}"
+    if dname:
+        dname = find_dname(dname).removeprefix('/')
+        url += f"/dialog_?{urlencode({'name': dname})}"
     if msg_id: url += f"#{msg_id}"
-    return HTML(f'<a href="{url}" target="_blank">{path}</a>') if path else Markdown(f'[{url}]({url})')
+    return HTML(f'<a href="{url}" target="_blank">{dname}</a>') if dname else Markdown(f'[{url}]({url})')
+
 
 # %% ../nbs/00_core.ipynb #c147990d
 @llmtool

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -787,16 +787,16 @@
      "data": {
       "text/html": [
        "<script>\n",
-       "if (Date.now() - 1776922909502 < 5000 && !window[\"_trig_1776922909502\"]) {\n",
-       "    window[\"_trig_1776922909502\"]=1;\n",
-       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"ed9dab23-17f8-4528-9afb-33e766226d29\"});\n",
+       "if (Date.now() - 1777220587786 < 5000 && !window[\"_trig_1777220587786\"]) {\n",
+       "    window[\"_trig_1777220587786\"]=1;\n",
+       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"e41e1010-52e0-4e00-86b1-a086f2654fe6\"});\n",
        "}</script>"
       ],
       "text/plain": [
        "HTML(<script>\n",
-       "if (Date.now() - 1776922909502 < 5000 && !window[\"_trig_1776922909502\"]) {\n",
-       "    window[\"_trig_1776922909502\"]=1;\n",
-       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"ed9dab23-17f8-4528-9afb-33e766226d29\"});\n",
+       "if (Date.now() - 1777220587786 < 5000 && !window[\"_trig_1777220587786\"]) {\n",
+       "    window[\"_trig_1777220587786\"]=1;\n",
+       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"e41e1010-52e0-4e00-86b1-a086f2654fe6\"});\n",
        "}</script>)"
       ]
      },
@@ -807,11 +807,11 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "{'data_id': 'ed9dab23-17f8-4528-9afb-33e766226d29', 'reply': 'it worked!'}\n",
+       "{'data_id': 'e41e1010-52e0-4e00-86b1-a086f2654fe6', 'reply': 'it worked!'}\n",
        "```"
       ],
       "text/plain": [
-       "{'data_id': 'ed9dab23-17f8-4528-9afb-33e766226d29', 'reply': 'it worked!'}"
+       "{'data_id': 'e41e1010-52e0-4e00-86b1-a086f2654fe6', 'reply': 'it worked!'}"
       ]
      },
      "execution_count": null,
@@ -855,13 +855,13 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "{ 'data_id': 'f8caa006-af3a-498a-abaa-367bda4b7236',\n",
+       "{ 'data_id': 'b6e36dd2-7d31-46fe-acf4-d47d35b62c39',\n",
        "  'error': 'No active dialog',\n",
        "  'ready': True}\n",
        "```"
       ],
       "text/plain": [
-       "{'data_id': 'f8caa006-af3a-498a-abaa-367bda4b7236',\n",
+       "{'data_id': 'b6e36dd2-7d31-46fe-acf4-d47d35b62c39',\n",
        " 'ready': True,\n",
        " 'error': 'No active dialog'}"
       ]
@@ -906,11 +906,11 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "{'data_id': '89c7d436-ec47-408d-bfcc-734e87e443b4', 'width': 1374}\n",
+       "{'data_id': 'f6e1be8a-46f2-47ef-98de-96338917dde6', 'width': 1920}\n",
        "```"
       ],
       "text/plain": [
-       "{'data_id': '89c7d436-ec47-408d-bfcc-734e87e443b4', 'width': 1374}"
+       "{'data_id': 'f6e1be8a-46f2-47ef-98de-96338917dde6', 'width': 1920}"
       ]
      },
      "execution_count": null,
@@ -932,11 +932,11 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "{'data_id': 'e8450d69-2b1a-4baa-a811-2e42ec0b4d89'}\n",
+       "{'data_id': '953b3ec0-48bd-4a1b-8c01-77e42bed6b80'}\n",
        "```"
       ],
       "text/plain": [
-       "{'data_id': 'e8450d69-2b1a-4baa-a811-2e42ec0b4d89'}"
+       "{'data_id': '953b3ec0-48bd-4a1b-8c01-77e42bed6b80'}"
       ]
      },
      "execution_count": null,
@@ -1017,7 +1017,7 @@
     {
      "data": {
       "text/plain": [
-       "{'path': '/Users/jhoward'}"
+       "{'path': '/Users/pengren/go/github.com/AnswerDotAI'}"
       ]
      },
      "execution_count": null,
@@ -1057,7 +1057,7 @@
     {
      "data": {
       "text/plain": [
-       "['04_exhash', '05_solve_auth', 'data/', 'index']"
+       "['03_tmux', '04_exhash', '05_solve_auth', 'index']"
       ]
      },
      "execution_count": null,
@@ -1078,7 +1078,7 @@
     {
      "data": {
       "text/plain": [
-       "['Applications/', 'CRAFT', 'CRAFTs/', 'Desktop/', 'Documents/']"
+       "['CRAFT_dup1', 'CRAFTs/', 'Notebook', 'R2', 'aai-ws/']"
       ]
      },
      "execution_count": null,
@@ -1444,7 +1444,7 @@
     {
      "data": {
       "text/plain": [
-       "'_ee8d802d'"
+       "'_8c98ea7e'"
       ]
      },
      "execution_count": null,
@@ -1812,7 +1812,7 @@
     {
      "data": {
       "text/plain": [
-       "'_671791b9'"
+       "'_29f9b479'"
       ]
      },
      "execution_count": null,
@@ -1856,7 +1856,7 @@
     {
      "data": {
       "text/plain": [
-       "'_d58171d3'"
+       "'_fc4fa9a7'"
       ]
      },
      "execution_count": null,
@@ -2624,7 +2624,7 @@
     {
      "data": {
       "text/plain": [
-       "{'success': 'deleted \"/Users/jhoward/aai-ws/dialoghelper/nbs/test_dialog\"'}"
+       "{'success': 'deleted \"/Users/pengren/go/github.com/AnswerDotAI/aai-ws/dialoghelper/nbs/test_dialog\"'}"
       ]
      },
      "execution_count": null,
@@ -3206,7 +3206,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('_92dd5022', '@@ -1 +1 @@\\n-hello world\\n+hi world'), ('_50fac793', '@@ -1 +1 @@\\n-hello there\\n+hi there')]\n"
+      "[('_ae12e79a', '@@ -1 +1 @@\\n-hello world\\n+hi world'), ('_5129bee3', '@@ -1 +1 @@\\n-hello there\\n+hi there')]\n"
      ]
     }
    ],
@@ -3337,14 +3337,14 @@
      "data": {
       "text/plain": [
        "[('xpost(url, data=data, headers=headers)',\n",
-       "  {'A': {'text': 'url',\n",
-       "    'range': {'byteOffset': {'start': 6001, 'end': 6004},\n",
-       "     'start': {'line': 122, 'column': 30},\n",
-       "     'end': {'line': 122, 'column': 33}}},\n",
-       "   'B': {'text': 'data',\n",
-       "    'range': {'byteOffset': {'start': 6011, 'end': 6015},\n",
-       "     'start': {'line': 122, 'column': 40},\n",
-       "     'end': {'line': 122, 'column': 44}}}},\n",
+       "  {'B': {'text': 'data',\n",
+       "    'range': {'byteOffset': {'start': 6213, 'end': 6217},\n",
+       "     'start': {'line': 125, 'column': 40},\n",
+       "     'end': {'line': 125, 'column': 44}}},\n",
+       "   'A': {'text': 'url',\n",
+       "    'range': {'byteOffset': {'start': 6203, 'end': 6206},\n",
+       "     'start': {'line': 125, 'column': 30},\n",
+       "     'end': {'line': 125, 'column': 33}}}},\n",
        "  'dialoghelper/core.py')]"
       ]
      },
@@ -4197,17 +4197,18 @@
     "#| export\n",
     "@llmtool\n",
     "def dialog_link(\n",
-    "    path:str='', # Path to dialog (e.g. '/aai-ws/dialoghelper/nbs/00_core'), defaults to current dialog\n",
+    "    dname:str='', # Dialog to link to (relative to current dialog's folder, or absolute if starts with '/'); empty for in-page anchor link\n",
     "    msg_id:str=None # Optional message id to scroll to\n",
     "):\n",
     "    \"\"\"Return an IPython HTML link to open a dialog in Solveit.\n",
     "    After calling this tool, output the resulting HTML anchor tag exactly as returned—do not wrap in a fenced code block or convert to markdown link format.\"\"\"\n",
-    "    if not (path or msg_id): return 'err: no path or id'\n",
-    "    path = path.removeprefix('/')\n",
+    "    if not (dname or msg_id): return 'err: no dname or msg_id'\n",
     "    url = ''\n",
-    "    if path: url += f\"/dialog_?{urlencode({'name': path})}\"\n",
+    "    if dname:\n",
+    "        dname = find_dname(dname).removeprefix('/')\n",
+    "        url += f\"/dialog_?{urlencode({'name': dname})}\"\n",
     "    if msg_id: url += f\"#{msg_id}\"\n",
-    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{path}</a>') if path else Markdown(f'[{url}]({url})')"
+    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{dname}</a>') if dname else Markdown(f'[{url}]({url})')\n"
    ]
   },
   {
@@ -4259,7 +4260,7 @@
     }
    ],
    "source": [
-    "dialog_link(path='/CRAFT')"
+    "dialog_link(dname='/CRAFT')"
    ]
   },
   {
@@ -4283,7 +4284,7 @@
     }
    ],
    "source": [
-    "dialog_link(path='/CRAFT', msg_id='_ce727fd8')"
+    "dialog_link(dname='/CRAFT', msg_id='_ce727fd8')"
    ]
   },
   {


### PR DESCRIPTION
Now dialog_link uses the same naming convention `dname` instead of `path`. Additionally, it uses `find_dname` so SolveIT does not need to know what the root folder is.

Before running in a dialog `chats/dialog.ipynb`
- `dialog_link('r2')` => link to `r2`

Now:
- `dialog_link('r2')` => links to `chats/r2`