### PR TITLE
dialog-link rendering issue

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -1230,8 +1230,8 @@ def dialog_link(
         dname = find_dname(dname).removeprefix('/')
         url += f"/dialog_?{urlencode({'name': dname})}"
     if msg_id: url += f"#{msg_id}"
-    return HTML(f'<a href="{url}" target="_blank">{dname}</a>') if dname else Markdown(f'[{url}]({url})')
-
+    label = f'{dname}/{msg_id}' if msg_id else dname
+    return HTML(f'<a href="{url}" target="_blank">{label}</a>') if dname else Markdown(f'[{url}]({url})')
 
 # %% ../nbs/00_core.ipynb #c147990d
 @llmtool

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -4208,7 +4208,8 @@
     "        dname = find_dname(dname).removeprefix('/')\n",
     "        url += f\"/dialog_?{urlencode({'name': dname})}\"\n",
     "    if msg_id: url += f\"#{msg_id}\"\n",
-    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{dname}</a>') if dname else Markdown(f'[{url}]({url})')\n"
+    "    label = f'{dname}/{msg_id}' if msg_id else dname\n",
+    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{label}</a>') if dname else Markdown(f'[{url}]({url})')"
    ]
   },
   {
@@ -4393,7 +4394,16 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit": {
+   "default_code": true,
+   "mode": "learning",
+   "use_fence": false,
+   "use_thinking": false,
+   "use_tools": true,
+   "ver": 2
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -4394,16 +4394,7 @@
    ]
   }
  ],
- "metadata": {
-  "solveit": {
-   "default_code": true,
-   "mode": "learning",
-   "use_fence": false,
-   "use_thinking": false,
-   "use_tools": true,
-   "ver": 2
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Small quality of life improvement. 

**Before**: Dialog link did not include the msg_id when present in the label (only in the link) that made the LLM add it with the weird issue that it becomes 2 separate links.

<img width="358" height="49" alt="image" src="https://github.com/user-attachments/assets/e34b360f-82e7-443e-8ebe-5632fd044a41" />


**After**:Adding it as a slash fixes it.

<img width="425" height="65" alt="image" src="https://github.com/user-attachments/assets/0dc433f7-6905-4b15-bf34-617929ec8fcd" />

I assume it's some weird markdown rendering issue, I am not sure if it's not worth digging much deeper though than this small fix