### PR TITLE
web search skill

### DIFF
--- a/dialoghelper/_modidx.py
+++ b/dialoghelper/_modidx.py
@@ -149,4 +149,5 @@ d = { 'settings': { 'branch': 'main',
             'dialoghelper.tracetools': { 'dialoghelper.tracetools._collapse': ('tracetools.html#_collapse', 'dialoghelper/tracetools.py'),
                                          'dialoghelper.tracetools._process': ('tracetools.html#_process', 'dialoghelper/tracetools.py'),
                                          'dialoghelper.tracetools.fmt_trace': ('tracetools.html#fmt_trace', 'dialoghelper/tracetools.py'),
-                                         'dialoghelper.tracetools.tracetool': ('tracetools.html#tracetool', 'dialoghelper/tracetools.py')}}}
+                                         'dialoghelper.tracetools.tracetool': ('tracetools.html#tracetool', 'dialoghelper/tracetools.py')},
+            'dialoghelper.websearchskill': {}}}

--- a/dialoghelper/websearchskill.py
+++ b/dialoghelper/websearchskill.py
@@ -1,0 +1,12 @@
+"""Web search and URL reading tools for models without native browser/search support.
+
+This skill exposes the Solveit web-search helpers as plain text-returning tools.
+"""
+
+from dialoghelper.core import *
+from ipykernel_helper import read_url
+from pyskills.core import allow
+
+__all__ = ['read_url', 'search', 'searches', 'web_answer']
+
+allow(read_url, search, searches, web_answer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dlg_connfiles = "dialoghelper.core:connfiles"
 [project.entry-points.pyskills]
 "dialoghelper.termskill" = "dialoghelper.termskill"
 "dialoghelper.solveitskill" = "dialoghelper.solveitskill"
+"dialoghelper.websearchskill" = "dialoghelper.websearchskill"
 
 [tool.nbdev]
 allowed_metadata_keys = ['solveit']


### PR DESCRIPTION
This PR creates a new `websearchskill` with the following tools: `read_url`, `search`, `searches`, `web_answer`. Solveit is transitioning into a minimal tool set (`pyrun` and `bash`), so we no longer include these as default tools but rather as skills.