### PR TITLE
Use `FullResponse` in `load_dialog`

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -715,7 +715,7 @@ async def load_dialog(
     dname:str='', # Target dialog; defaults to current dialog
 ):
     "Run all code messages from `src_dname` into the target dialog's kernel and return dialog contents."
-    return _lt.ToolResponse({'_full': await call_endpa('load_dialog_', dname, src_dname=src_dname)})
+    return _lt.FullResponse(await call_endpa('load_dialog_', dname, src_dname=src_dname))
 
 # %% ../nbs/00_core.ipynb #e393f14b
 async def rm_dialog(

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2670,7 +2670,7 @@
     "    dname:str='', # Target dialog; defaults to current dialog\n",
     "):\n",
     "    \"Run all code messages from `src_dname` into the target dialog's kernel and return dialog contents.\"\n",
-    "    return _lt.ToolResponse({'_full': await call_endpa('load_dialog_', dname, src_dname=src_dname)})"
+    "    return _lt.FullResponse(await call_endpa('load_dialog_', dname, src_dname=src_dname))"
    ]
   },
   {


### PR DESCRIPTION
In https://github.com/AnswerDotAI/solveit/pull/1796, we removed the redundant `ToolResponse.content['full']` approach and promoted `FullResponse` for returning full tool results. An `aai-ws`-wide search showed that only `load_dialog` used that pattern, so it now uses `FullResponse` instead.