### PR TITLE
Add fastspec to allowed imports

### DIFF
--- a/dialoghelper/stdtools.py
+++ b/dialoghelper/stdtools.py
@@ -8,7 +8,7 @@ from safepyrun.core import allow_imports
 from safecmd import bash
 from safepyrun import RunPython
 
-for o in ('fastllm', 'PIL'): allow_imports.add(o)
+for o in ('fastllm', 'PIL', 'fastspec'): allow_imports.add(o)
 from exhash import lnhashview_file,exhash_file
 allow(lnhashview_file, exhash_file)
 


### PR DESCRIPTION
## Changes

 Adds `fastspec` to the list of allowed imports in `stdtools.py`, alongside the existing `fastllm` and `PIL` entries.

This is required to prevent the error cause by @patch which internally calls [object.__setattr__](https://docs.python.org/3/reference/datamodel.html#object.__setattr__) on the function object (to fix up __code__/__qualname__), and the sandbox's audit hook blocked exactly that — object.__setattr__ blocked in sandbox.