### PR TITLE
Renamed create_pyrun_magic to create_python_magic 

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -40,7 +40,7 @@ from toolslm.xml import *
 from fasthtml.common import *
 from fasthtml.components import Solveit_input
 from urllib.parse import urlencode
-from safepyrun import RunPython,find_var,create_pyrun_magic,load_ipython_extension
+from safepyrun import RunPython,find_var,create_python_magic,load_ipython_extension
 from pyskills import allow
 from pyskills.edit import *
 

--- a/dialoghelper/stdtools.py
+++ b/dialoghelper/stdtools.py
@@ -8,7 +8,7 @@ from safepyrun.core import allow_imports
 from safecmd import bash
 from safepyrun import RunPython
 
-for o in ('fastllm', 'PIL'): allow_imports.add(o)
+for o in ('fastllm', 'PIL', 'fastspec'): allow_imports.add(o)
 from exhash import lnhashview_file,exhash_file
 allow(lnhashview_file, exhash_file)
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -58,7 +58,7 @@
     "from fasthtml.common import *\n",
     "from fasthtml.components import Solveit_input\n",
     "from urllib.parse import urlencode\n",
-    "from safepyrun import RunPython,find_var,create_pyrun_magic,load_ipython_extension\n",
+    "from safepyrun import RunPython,find_var,create_python_magic,load_ipython_extension\n",
     "from pyskills import allow\n",
     "from pyskills.edit import *"
    ]
@@ -4408,6 +4408,9 @@
   }
  ],
  "metadata": {
+  "language_info": {
+   "name": "python"
+  },
   "solveit": {
    "default_code": true,
    "mode": "concise",


### PR DESCRIPTION
## Changes

 - Renamed import from `create_pyrun_magic` → `create_python_magic` in `core.py` due to changes in `safepyrun`.