### PR TITLE
Add xdir to pyskills imports in stdtools

### DIFF
--- a/dialoghelper/stdtools.py
+++ b/dialoghelper/stdtools.py
@@ -2,7 +2,7 @@ from dialoghelper import *
 from fastcore.tools import *
 from toolslm.xml import *
 from toolslm.inspecttools import *
-from pyskills import allow,doc,list_pyskills
+from pyskills import allow,doc,list_pyskills,xdir
 from pyskills.edit import *
 from safepyrun.core import allow_imports
 from safecmd import bash


### PR DESCRIPTION
## Changes

-Added `xdir` to `stdtools.py` because it's used by the [notools PR](https://github.com/AnswerDotAI/solveit/pull/1798)