### PR TITLE
Add unlock() call to load_dialog and ipymini dependency

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -30,6 +30,7 @@ from fastcore.xtras import asdict,acache
 from fastcore.docments import MarkdownRenderer
 from ghapi.all import *
 from inspect import currentframe,Parameter,signature
+from ipymini import unlock
 from httpx import AsyncClient, get as xget, post as xpost
 from IPython.display import display,Markdown,HTML
 from monsterui.all import franken_class_map,apply_classes
@@ -670,6 +671,7 @@ async def load_dialog(
     dname:str='', # Target dialog; defaults to current dialog
 ):
     "Run all code messages from `src_dname` into the target dialog's kernel and return dialog contents."
+    unlock()
     return _lt.FullResponse(await call_endpa('load_dialog_', dname, src_dname=src_dname))
 
 # %% ../nbs/00_core.ipynb #e393f14b

--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -109,11 +109,11 @@ def _handle_resp(res, json, raiseex):
     except Exception: return res.text
 
 # %% ../nbs/00_core.ipynb #5fc896fe
-def call_endp(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=5, **data):
+def call_endp(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=10, **data):
     url, data, headers = _prep_endp(path, dname, json, id, data, required=required)
     return _handle_resp(xpost(url, data=data, headers=headers, timeout=timeout), json, raiseex)
 
-async def call_endpa(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=5, **data):
+async def call_endpa(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=10, **data):
     url, data, headers = _prep_endp(path, dname, json, id, data, required=required)
     return _handle_resp(await xposta(url, data=data, headers=headers, timeout=timeout), json, raiseex)
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -51,6 +51,7 @@
     "from fastcore.docments import MarkdownRenderer\n",
     "from ghapi.all import *\n",
     "from inspect import currentframe,Parameter,signature\n",
+    "from ipymini import unlock\n",
     "from httpx import AsyncClient, get as xget, post as xpost\n",
     "from IPython.display import display,Markdown,HTML\n",
     "from monsterui.all import franken_class_map,apply_classes\n",
@@ -2496,6 +2497,7 @@
     "    dname:str='', # Target dialog; defaults to current dialog\n",
     "):\n",
     "    \"Run all code messages from `src_dname` into the target dialog's kernel and return dialog contents.\"\n",
+    "    unlock()\n",
     "    return _lt.FullResponse(await call_endpa('load_dialog_', dname, src_dname=src_dname))"
    ]
   },

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -393,11 +393,11 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def call_endp(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=5, **data):\n",
+    "def call_endp(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=10, **data):\n",
     "    url, data, headers = _prep_endp(path, dname, json, id, data, required=required)\n",
     "    return _handle_resp(xpost(url, data=data, headers=headers, timeout=timeout), json, raiseex)\n",
     "\n",
-    "async def call_endpa(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=5, **data):\n",
+    "async def call_endpa(path, dname='', json=False, raiseex=False, id=None, required=True, timeout=10, **data):\n",
     "    url, data, headers = _prep_endp(path, dname, json, id, data, required=required)\n",
     "    return _handle_resp(await xposta(url, data=data, headers=headers, timeout=timeout), json, raiseex)"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   'fastcore>=1.13.4',
   'ghapi',
   'ipykernel-helper>=0.0.28',
+  'ipymini>=0.1.9',
   'MonsterUI',
   'lisette>=0.1.30',
   'toolslm>=0.3.30',


### PR DESCRIPTION
## Summary

Integrates `ipymini` as a dependency and calls `unlock()` at the start of `load_dialog` to prevent deadlock

## Changes
- Import and call `unlock()` from `ipymini` in `load_dialog`
- Add `ipymini>=0.1.9` to project dependencies in `pyproject.toml`