### PR TITLE
feat: support top-level await in js_eval via async IIFE wrapper

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -272,13 +272,13 @@ async def js_run_a(code):
 def js_eval(expr):
     "Evaluate a JS expression in the browser and return the result"
     idx, data = _event_prep({})
-    iife("pushData('%s', (() => { %s })())" % (idx, expr))
+    iife("pushData('%s', { result: await (async () => { %s })() })" % (idx, expr))
     return pop_data(idx)
 
 async def js_eval_a(expr):
     "Evaluate a JS expression in the browser and return the result"
     idx, data = _event_prep({})
-    await iife_a("pushData('%s', (() => { %s })())" % (idx, expr))
+    await iife_a("pushData('%s', { result: await (async () => { %s })() })" % (idx, expr))
     return await pop_data_a(idx)
 
 # %% ../nbs/00_core.ipynb #80334098

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -690,16 +690,16 @@
      "data": {
       "text/html": [
        "<script>\n",
-       "if (Date.now() - 1781724235461 < 5000 && !window[\"_trig_1781724235461\"]) {\n",
-       "    window[\"_trig_1781724235461\"]=1;\n",
-       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"0ec67577-073e-4fac-add1-97de90c24ab0\"});\n",
+       "if (Date.now() - 1781802624687 < 5000 && !window[\"_trig_1781802624687\"]) {\n",
+       "    window[\"_trig_1781802624687\"]=1;\n",
+       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"1727d927-09f3-4786-9b54-eca2ba13d455\"});\n",
        "}</script>"
       ],
       "text/plain": [
        "HTML(<script>\n",
-       "if (Date.now() - 1781724235461 < 5000 && !window[\"_trig_1781724235461\"]) {\n",
-       "    window[\"_trig_1781724235461\"]=1;\n",
-       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"0ec67577-073e-4fac-add1-97de90c24ab0\"});\n",
+       "if (Date.now() - 1781802624687 < 5000 && !window[\"_trig_1781802624687\"]) {\n",
+       "    window[\"_trig_1781802624687\"]=1;\n",
+       "    htmx.trigger(document.body, 'test_evt', {\"data\": {\"hello\": \"world\"}, \"idx\": \"1727d927-09f3-4786-9b54-eca2ba13d455\"});\n",
        "}</script>)"
       ]
      },
@@ -712,13 +712,13 @@
        "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "{'data_id': '0ec67577-073e-4fac-add1-97de90c24ab0', 'reply': 'it worked!'}\n",
+       "{'data_id': '1727d927-09f3-4786-9b54-eca2ba13d455', 'reply': 'it worked!'}\n",
        "```\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "{'data_id': '0ec67577-073e-4fac-add1-97de90c24ab0', 'reply': 'it worked!'}"
+       "{'data_id': '1727d927-09f3-4786-9b54-eca2ba13d455', 'reply': 'it worked!'}"
       ]
      },
      "execution_count": null,
@@ -764,7 +764,7 @@
        "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "{ 'data_id': '0bc0f3c4-3065-4687-8e0b-05068c2ba597',\n",
+       "{ 'data_id': 'f666f868-289c-4a97-9e1b-ebf3d0a5a241',\n",
        "  'error': 'No active dialog',\n",
        "  'ready': True}\n",
        "```\n",
@@ -772,7 +772,7 @@
        "</div>"
       ],
       "text/plain": [
-       "{'data_id': '0bc0f3c4-3065-4687-8e0b-05068c2ba597',\n",
+       "{'data_id': 'f666f868-289c-4a97-9e1b-ebf3d0a5a241',\n",
        " 'ready': True,\n",
        " 'error': 'No active dialog'}"
       ]
@@ -797,13 +797,13 @@
     "def js_eval(expr):\n",
     "    \"Evaluate a JS expression in the browser and return the result\"\n",
     "    idx, data = _event_prep({})\n",
-    "    iife(\"pushData('%s', (() => { %s })())\" % (idx, expr))\n",
+    "    iife(\"pushData('%s', { result: await (async () => { %s })() })\" % (idx, expr))\n",
     "    return pop_data(idx)\n",
     "\n",
     "async def js_eval_a(expr):\n",
     "    \"Evaluate a JS expression in the browser and return the result\"\n",
     "    idx, data = _event_prep({})\n",
-    "    await iife_a(\"pushData('%s', (() => { %s })())\" % (idx, expr))\n",
+    "    await iife_a(\"pushData('%s', { result: await (async () => { %s })() })\" % (idx, expr))\n",
     "    return await pop_data_a(idx)"
    ]
   },
@@ -819,13 +819,13 @@
        "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "{'data_id': '027c22cf-55fb-44be-8390-225891b6fd80', 'width': 1374}\n",
+       "{'data_id': 'b3f5fb2a-1254-46da-ba76-a1a1b0139241', 'result': {'width': 1449}}\n",
        "```\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "{'data_id': '027c22cf-55fb-44be-8390-225891b6fd80', 'width': 1374}"
+       "{'data_id': 'b3f5fb2a-1254-46da-ba76-a1a1b0139241', 'result': {'width': 1449}}"
       ]
      },
      "execution_count": null,
@@ -849,13 +849,13 @@
        "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "{'data_id': '7f7a6017-6823-47c2-bb5d-af38dc8ebd89'}\n",
+       "{'data_id': 'f270c22b-1770-4839-ba27-1c6ceaff082b', 'result': 0}\n",
        "```\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "{'data_id': '7f7a6017-6823-47c2-bb5d-af38dc8ebd89'}"
+       "{'data_id': 'f270c22b-1770-4839-ba27-1c6ceaff082b', 'result': 0}"
       ]
      },
      "execution_count": null,
@@ -865,6 +865,69 @@
    ],
    "source": [
     "js_eval(\"return document.querySelectorAll('.msg').length\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e37e9a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<div class=\"prose\" markdown=\"1\">\n",
+       "\n",
+       "```python\n",
+       "{'data_id': 'b5d78510-5da2-4b89-a7a3-84d91ffaf0a7', 'result': 2}\n",
+       "```\n",
+       "\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "{'data_id': 'b5d78510-5da2-4b89-a7a3-84d91ffaf0a7', 'result': 2}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "js_eval(\"a=1\")\n",
+    "js_eval(\"return a+1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "147aca75",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<div class=\"prose\" markdown=\"1\">\n",
+       "\n",
+       "```python\n",
+       "{ 'data_id': 'bdf67a98-88ec-4968-b96a-e3c3a209375d',\n",
+       "  'result': {'error': 'No active dialog'}}\n",
+       "```\n",
+       "\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "{'data_id': 'bdf67a98-88ec-4968-b96a-e3c3a209375d',\n",
+       " 'result': {'error': 'No active dialog'}}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "await js_eval_a(\"return (await fetch('/curr_dialog_', {method:'POST'})).json()\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Wraps the evaluated JS expression in an `async` IIFE, enabling `await` at the top level of expressions passed to `js_eval` and `js_eval_a`.

## Changes

- `js_eval`: wraps expression in `async () => { ... }` and awaits the result before pushing data
- `js_eval_a`: same treatment for the async variant