### PR TITLE
Fix KeyError when reading/viewing a missing or errored message

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -533,6 +533,7 @@ async def read_msgid(
     """Get message `id`. Message IDs can be view directly in LLM chat history/context, or found in `find_msgs` results.
     Use `add_to_dlg` if the LLM or human may need to refer to the message content again later."""
     res = await read_msg(0, id=id, start_line=start_line, end_line=end_line, nums=nums, lnhashs=lnhashs, dname=dname)
+    if 'error' in res: return res
     if add_to_dlg: await add_msg(res['content'], msg_type='raw')
     return res
 
@@ -551,6 +552,7 @@ async def view_msg(
     """Views the *content* of message `id`. Same as `read_msgid(...)['content']`, defaulting to `nums=True`.
     Use `add_to_dlg` if the LLM or human may need to refer to the message content again later."""
     r = await read_msg(0, id=id, start_line=start_line, end_line=end_line, nums=nums, lnhashs=lnhashs, dname=dname)
+    if 'error' in r: return f"error: {r['error']}"
     res = r['content']
     if incl_out and (o := r.get('output')): res += f"\n<out>\n{truncstr(o, 512) if trunc_out else o}\n</out>"
     if add_to_dlg: await add_msg(res, msg_type='raw')

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1611,6 +1611,7 @@
     "    \"\"\"Get message `id`. Message IDs can be view directly in LLM chat history/context, or found in `find_msgs` results.\n",
     "    Use `add_to_dlg` if the LLM or human may need to refer to the message content again later.\"\"\"\n",
     "    res = await read_msg(0, id=id, start_line=start_line, end_line=end_line, nums=nums, lnhashs=lnhashs, dname=dname)\n",
+    "    if 'error' in res: return res\n",
     "    if add_to_dlg: await add_msg(res['content'], msg_type='raw')\n",
     "    return res"
    ]
@@ -1684,6 +1685,7 @@
     "    \"\"\"Views the *content* of message `id`. Same as `read_msgid(...)['content']`, defaulting to `nums=True`.\n",
     "    Use `add_to_dlg` if the LLM or human may need to refer to the message content again later.\"\"\"\n",
     "    r = await read_msg(0, id=id, start_line=start_line, end_line=end_line, nums=nums, lnhashs=lnhashs, dname=dname)\n",
+    "    if 'error' in r: return f\"error: {r['error']}\"\n",
     "    res = r['content']\n",
     "    if incl_out and (o := r.get('output')): res += f\"\\n<out>\\n{truncstr(o, 512) if trunc_out else o}\\n</out>\"\n",
     "    if add_to_dlg: await add_msg(res, msg_type='raw')\n",
@@ -1705,7 +1707,9 @@
     }
    ],
    "source": [
-    "print((await view_msg(r.id)))"
+    "print((await view_msg(r.id)))\n",
+    "assert (await view_msg(r.id, start_line=9999)).startswith('error:')\n",
+    "assert 'error' in await read_msgid(r.id, start_line=9999, add_to_dlg=True)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`read_msgid` and `view_msg` passed the result of `read_msg` straight into downstream logic that indexes `['content']`. When `read_msg` returned an error dict (e.g. an out-of-bounds or non-existent message id), the functions crashed with a `KeyError` instead of surfacing the error.

## Changes

- `read_msgid`: return early if `'error'` is present in the `read_msg` result.
- `view_msg`: return an `error: ...` string early under the same condition, consistent with its existing return type.