### PR TITLE
Update msg imports from fastllm -> aidialog

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -46,7 +46,7 @@ from pyskills import allow
 from fastcore.tools import *
 
 # %% ../nbs/00_core.ipynb #c9936691
-_lt = import_no_init('fastllm.chat')
+_lt = import_no_init('aidialog.msg_parts')
 
 # %% ../nbs/00_core.ipynb #eb1636a6
 dh_settings = {'port':5001}

--- a/dialoghelper/utils.py
+++ b/dialoghelper/utils.py
@@ -38,7 +38,7 @@ from .core import *
 from .core import _msg_edit
 
 # %% ../nbs/06_utils.ipynb #c9936691
-_lt = import_no_init('fastllm.chat')
+_lt = import_no_init('aidialog.msg_parts')
 
 # %% ../nbs/06_utils.ipynb #cc9f963f
 md_cls_d = {

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "_lt = import_no_init('fastllm.chat')"
+    "_lt = import_no_init('aidialog.msg_parts')"
    ]
   },
   {
@@ -2615,7 +2615,8 @@
     "    \"Read URL as markdown, and add note(s) below current message with the result\"\n",
     "    res = read_url(url, as_md=True, extract_section=extract_section, selector=selector, ai_img=ai_img)\n",
     "    if split_re: return [await add_msg(s) for s in re.split(split_re, res, flags=re.MULTILINE)[::-1] if s.strip()]\n",
-    "    return await add_msg(res)\n"
+    "    return await add_msg(res)\n",
+    ""
    ]
   },
   {
@@ -2867,7 +2868,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "msg_insert_line  = _msg_edit (insert_line, 'msg_insert_line')\n"
+    "msg_insert_line  = _msg_edit (insert_line, 'msg_insert_line')\n",
+    ""
    ]
   },
   {
@@ -2923,7 +2925,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "msg_str_replace =  _msg_edit (str_replace, 'msg_str_replace')\n"
+    "msg_str_replace =  _msg_edit (str_replace, 'msg_str_replace')\n",
+    ""
    ]
   },
   {
@@ -2989,7 +2992,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "msg_strs_replace =  _msg_edit (strs_replace, 'msg_strs_replace')\n"
+    "msg_strs_replace =  _msg_edit (strs_replace, 'msg_strs_replace')\n",
+    ""
    ]
   },
   {
@@ -3046,7 +3050,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "msg_replace_lines =  _msg_edit (replace_lines, 'msg_replace_lines')\n"
+    "msg_replace_lines =  _msg_edit (replace_lines, 'msg_replace_lines')\n",
+    ""
    ]
   },
   {
@@ -3106,7 +3111,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "msg_del_lines =  _msg_edit (del_lines, 'msg_del_lines')\n"
+    "msg_del_lines =  _msg_edit (del_lines, 'msg_del_lines')\n",
+    ""
    ]
   },
   {
@@ -3270,7 +3276,8 @@
     "        dname = find_dname(dname).removeprefix('/')\n",
     "        url += f\"/dialog_?{urlencode({'name': dname})}\"\n",
     "    if msg_id: url += '#_'+str(msg_id).removeprefix('_')  # the fragment targets the DOM id, which carries a `_` prefix\n",
-    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{dname}</a>') if dname else Markdown(f'[{url}]({url})')\n"
+    "    return HTML(f'<a href=\"{url}\" target=\"_blank\">{dname}</a>') if dname else Markdown(f'[{url}]({url})')\n",
+    ""
    ]
   },
   {

--- a/nbs/06_utils.ipynb
+++ b/nbs/06_utils.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "_lt = import_no_init('fastllm.chat')"
+    "_lt = import_no_init('aidialog.msg_parts')"
    ]
   },
   {
@@ -508,7 +508,8 @@
     "    if exts: types=None\n",
     "    res = folder2ctx(path, types=types, out=out, exts=exts, **kwargs)\n",
     "    if not raw: res = f'```\\n{res}\\n```'\n",
-    "    return await add_msg(res, msg_type='raw' if raw else 'note')\n"
+    "    return await add_msg(res, msg_type='raw' if raw else 'note')\n",
+    ""
    ]
   },
   {
@@ -585,7 +586,8 @@
     "#| export\n",
     "async def ctx_symfile(sym):\n",
     "    \"Add note with filepath and contents for a symbol's source file\"\n",
-    "    return await add_msg(sym2file(sym), msg_type='note');\n"
+    "    return await add_msg(sym2file(sym), msg_type='note');\n",
+    ""
    ]
   },
   {
@@ -611,7 +613,8 @@
     "    sym, # Symbol to get folder context from\n",
     "    **kwargs):\n",
     "    \"Add raw message with folder context for a symbol's source file location\"\n",
-    "    return await add_msg(sym2folderctx(sym, **kwargs), msg_type='raw');\n"
+    "    return await add_msg(sym2folderctx(sym, **kwargs), msg_type='raw');\n",
+    ""
    ]
   },
   {
@@ -637,7 +640,8 @@
     "    sym, # Symbol to get folder context from\n",
     "    **kwargs):\n",
     "    \"Add raw message with repo context for a symbol's root package\"\n",
-    "    return await add_msg(sym2pkgctx(sym, **kwargs), msg_type='raw');\n"
+    "    return await add_msg(sym2pkgctx(sym, **kwargs), msg_type='raw');\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
> [!NOTE]
> This PR relies on [this aidialog PR](https://github.com/AnswerDotAI/aidialog/pull/8) and [this fastllm PR](https://github.com/AnswerDotAI/fastllm/pull/73) being merged beforehand

This PR fixes an invalid import bug, specifically `FullResponse` can't be imported from `fastllm.chat`. Special message classes have now been moved to `aidialog -> 00_msg_parts.ipynb`, so the `_lt` lazy import now imports the classes from `aidialog.msg_parts`.