### PR TITLE
Re-import solveitskill functions after allow wrapping

### DIFF
--- a/dialoghelper/solveitskill.py
+++ b/dialoghelper/solveitskill.py
@@ -72,3 +72,6 @@ allow(
     del_msgs, update_msg, copy_msgs, paste_msgs, toggle_header, toggle_bookmark, toggle_comment,
     create_or_run_dialog, stop_dialog, load_dialog, solveit_docs, dialog_link, spawn_agent, lnhashview_msg, msg_exhash
 )
+
+from dialoghelper.core import *
+from dialoghelper.exhash import *


### PR DESCRIPTION
`solveitskill` imports its public functions before passing them to `allow()`. For async functions, `allow()` installs a tracked wrapper in the defining module, while the existing `solveitskill` alias continues to reference the original function. Calls imported from `dialoghelper.solveitskill`, such as `add_msg`, therefore lose their trusted context across `await` and Rustygate operations fail with a permission error.

Re-importing from `dialoghelper.core` and `dialoghelper.exhash` after `allow()` updates the public exports to reference the installed wrappers. The public API is unchanged.
