### PR TITLE
Import APIError from fasttransport

### DIFF
--- a/dialoghelper/core.py
+++ b/dialoghelper/core.py
@@ -41,7 +41,7 @@ import aidialog.dialog as adlg
 import aidialog.ipynb  # chkstyle: ignore  (patches serialization onto the model classes, which `Message.cell_meta` below extends)
 import aidialog.dlgskill
 from jupyasyncclient import JupyAsyncCellsClient
-from fastspec.errors import APIError
+from fasttransport.errors import APIError
 from fastcore.nbio import select_cells, item2xml
 from safepyrun import RunPython,find_var,create_python_magic,load_ipython_extension
 from functools import cache

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -61,7 +61,7 @@
     "import aidialog.ipynb  # chkstyle: ignore  (patches serialization onto the model classes, which `Message.cell_meta` below extends)\n",
     "import aidialog.dlgskill\n",
     "from jupyasyncclient import JupyAsyncCellsClient\n",
-    "from fastspec.errors import APIError\n",
+    "from fasttransport.errors import APIError\n",
     "from fastcore.nbio import select_cells, item2xml\n",
     "from safepyrun import RunPython,find_var,create_python_magic,load_ipython_extension\n",
     "from functools import cache\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = ["Natural Language :: English", "Intended Audience :: Developers",
 dependencies = [
   'aidialog>=0.0.23',
   'fastcore>=2.2.7',
+  'fasttransport>=0.0.2',
   'ghapi>=2.0.0',
   'ipykernel-helper>=0.0.28',
   'ipymini>=0.1.21',


### PR DESCRIPTION
`APIError` now comes from `fasttransport.errors`, which is where the class lives after fastspec dropped it. Code catching `fastspec.errors.APIError` around these calls must catch `fasttransport.errors.APIError` instead. It is the same class, moved.